### PR TITLE
Use the relay to control heater in addition to SSR

### DIFF
--- a/include/roaster.h
+++ b/include/roaster.h
@@ -14,14 +14,15 @@
 #define TEMPERATURE_TC(x)      x[TEMPERATURE_CHANNEL_THERMOCOUPLE]
 
 // PIN Definitions
-#define PIN_LED     PA3
-#define PIN_EXHAUST PA8
-#define PIN_DRUM    PA15
-#define PIN_HEAT    PB9
-#define PIN_NTC     PC5
-#define PIN_COOL    PC8
+#define PIN_LED         PA3
+#define PIN_EXHAUST     PA8
+#define PIN_DRUM        PA15
+#define PIN_HEAT_RELAY  PB8
+#define PIN_HEAT        PB9
+#define PIN_NTC         PC5
+#define PIN_COOL        PC8
 
-#define SPI_BTCS            PA4
+#define SPI_BTCS        PA4
 
 // PWM frequencies Hz
 #define PWM_FREQ_COOL       60

--- a/src/state_commanded.cpp
+++ b/src/state_commanded.cpp
@@ -7,6 +7,11 @@ ControlBasic::ControlBasic() {
 }
 
 
+bool ControlBasic::loopTick() {
+    return true;
+}
+
+
 bool StateCommanded::begin() {
     bool isSuccess = true;
 
@@ -20,7 +25,14 @@ bool StateCommanded::begin() {
 
 
 bool StateCommanded::loopTick() {
-    return true;
+    bool isSuccess = true;
+    isSuccess &= this->heat.loopTick();
+    isSuccess &= this->vent.loopTick();
+    isSuccess &= this->drum.loopTick();
+    isSuccess &= this->cool.loopTick();
+    isSuccess &= this->filter.loopTick();
+
+    return isSuccess;
 }
 
 
@@ -111,4 +123,22 @@ void ControlPWM::_setAction(uint8_t value) {
         // set pwm to 0
         timer->setPWM(this->channel, this->pin, this->freq, value);
     }
+}
+
+
+bool ControlHeat::begin() {
+    pinMode(PIN_HEAT_RELAY, OUTPUT);
+    digitalWrite(PIN_HEAT_RELAY, LOW);
+
+    return ControlPWM::begin();
+}
+
+
+bool ControlHeat::loopTick() {
+    return true;
+}
+
+
+void ControlHeat::_setAction(uint8_t value) {
+    ControlPWM::_setAction(value);
 }

--- a/src/state_commanded.cpp
+++ b/src/state_commanded.cpp
@@ -127,10 +127,11 @@ void ControlPWM::_setAction(uint8_t value) {
 
 
 bool ControlHeat::begin() {
-    pinMode(PIN_HEAT_RELAY, OUTPUT);
-    digitalWrite(PIN_HEAT_RELAY, LOW);
+    bool isSuccess = true;
+    isSuccess &= this->heatRelay.begin();
+    isSuccess &= ControlPWM::begin();
 
-    return ControlPWM::begin();
+    return isSuccess;
 }
 
 
@@ -141,11 +142,11 @@ bool ControlHeat::loopTick() {
             ControlPWM::_setAction(this->oldValue);
         } else {
             // transitioning to OFF, turn off the relay
-            digitalWrite(PIN_HEAT_RELAY, LOW);
+            this->heatRelay.off();
         }
     }
 
-    return true;
+    return this->heatRelay.loopTick();
 }
 
 
@@ -164,7 +165,7 @@ void ControlHeat::_setAction(uint8_t newValue) {
         if ( newIsOn ) {
             // The state is transitioning to ON
             // turn on the Relay and loopTick will set the new PWM value
-            digitalWrite(PIN_HEAT_RELAY, HIGH);
+            this->heatRelay.on();
         }
     }
 }

--- a/src/state_commanded.h
+++ b/src/state_commanded.h
@@ -57,6 +57,7 @@ class ControlHeat: public ControlPWM {
     private:
         bool isTransitioning = false;
         uint8_t oldValue = 0;
+        ControlOnOff heatRelay = ControlOnOff(PIN_HEAT_RELAY);
 };
 
 

--- a/src/state_commanded.h
+++ b/src/state_commanded.h
@@ -50,9 +50,13 @@ class ControlHeat: public ControlPWM {
         ControlHeat(): ControlPWM(PIN_HEAT, PWM_FREQ_HEAT) {};
         bool begin();
         bool loopTick();
-    
+
     protected:
         void _setAction(uint8_t value);
+
+    private:
+        bool isTransitioning = false;
+        uint8_t oldValue = 0;
 };
 
 

--- a/src/state_commanded.h
+++ b/src/state_commanded.h
@@ -12,9 +12,12 @@ class ControlBasic {
         void virtual on();
         uint8_t virtual get();
         void virtual set(uint8_t value);
+        bool virtual loopTick();
 
     private:
         uint8_t         value;
+    
+    protected:
         void virtual _setAction(uint8_t value) {};
 };
 
@@ -25,8 +28,6 @@ class ControlOnOff: public ControlBasic {
 
     protected:
         const uint8_t   pin;
-
-    private:
         void _setAction(uint8_t value);
 };
 
@@ -39,13 +40,25 @@ class ControlPWM: public ControlOnOff {
         HardwareTimer*  timer;
         uint32_t        channel;
         uint32_t        freq;
+    
+    protected:
+        void _setAction(uint8_t value);
+};
+
+class ControlHeat: public ControlPWM {
+    public:
+        ControlHeat(): ControlPWM(PIN_HEAT, PWM_FREQ_HEAT) {};
+        bool begin();
+        bool loopTick();
+    
+    protected:
         void _setAction(uint8_t value);
 };
 
 
 class StateCommanded {
     public:
-        ControlPWM heat     = ControlPWM(PIN_HEAT, PWM_FREQ_HEAT);
+        ControlHeat heat;
         ControlPWM vent     = ControlPWM(PIN_EXHAUST, PWM_FREQ_EXHAUST);
         ControlPWM drum     = ControlPWM(PIN_DRUM, PWM_FREQ_DRUM);
         ControlOnOff cool   = ControlOnOff(PIN_COOL);


### PR DESCRIPTION
Use the relay to control the heater in addition to SSR. This is just a failback, to turn off the heater in case of SSR thermal runaway.

When turning on -> turn on the relay first, then control the SSR.
When turning off -> turn off the SSR, then turn on the relay.