### PR TITLE
Fix ControlHeat class to ensure the delay between the SSR and relay controls

### DIFF
--- a/src/state_commanded.cpp
+++ b/src/state_commanded.cpp
@@ -165,7 +165,7 @@ void ControlHeat::_setAction(uint8_t newValue) {
     this->oldValue = newValue;
 
     if ( isTransitioning ) {
-        if ( NULL != transitionTimer ) {
+        if ( NULL == transitionTimer ) {
             this->begin();
         }
         this->transitionTimer->reset();

--- a/src/state_commanded.cpp
+++ b/src/state_commanded.cpp
@@ -1,3 +1,5 @@
+#include <logging.h>
+
 #include "state.h"
 #include "state_commanded.h"
 
@@ -122,6 +124,8 @@ void ControlPWM::_setAction(uint8_t value) {
     } else {
         // set pwm to 0
         timer->setPWM(this->channel, this->pin, this->freq, value);
+        timer->refresh();
+        DEBUG(micros()); DEBUG(F(" PWM::_setAction value: ")); DEBUGLN(value);
     }
 }
 

--- a/src/state_commanded.h
+++ b/src/state_commanded.h
@@ -2,7 +2,12 @@
 #define _SW_STATE_CMD_PH
 
 #include <HardwareTimer.h>
+#include <tick-timer.h>
+
 #include "roaster.h"
+
+// delay between SSR and heat relay transitions
+#define CONTROL_HEAT_SSR_RELAY_DELAY_MS 11U
 
 class ControlBasic {
     public:
@@ -57,6 +62,7 @@ class ControlHeat: public ControlPWM {
     private:
         bool isTransitioning = false;
         uint8_t oldValue = 0;
+        TimerMS *transitionTimer;
         ControlOnOff heatRelay = ControlOnOff(PIN_HEAT_RELAY);
 };
 


### PR DESCRIPTION
When turning on the Heater: Turn on the relay 1st, then after aprox 11ms delay, turn on the SSR
When turning off the Heater: Turn off the SSR immediately, the turn off the relay after 11ms delay
For PWM control class, update/refresh the timer, upon duty cycle change. This it mostly to enforce an immediate output off.