### PR TITLE
Implement temperature safety monitor

### DIFF
--- a/include/state.h
+++ b/include/state.h
@@ -36,6 +36,7 @@ class Reported {
         void printStatistics();
         uint8_t getChanMapping(uint8_t idx);
         void setChanMapping(uint8_t idx, uint8_t mapping);
+        float getChanTemp(uint8_t chan);
     
     private:
         Adafruit_MAX31855   *tc1;

--- a/platformio.ini
+++ b/platformio.ini
@@ -31,6 +31,14 @@ upload_protocol = dfu
 extends = skyduino
 
 
+[env:skyduino-debug]
+extends = skyduino
+build_flags =
+  ${skyduino.build_flags}
+  -D __DEBUG__
+  -D __WARN__
+
+
 [skyduino]
 platform = ststm32
 board = skyduino_stm32f412re

--- a/platformio.ini
+++ b/platformio.ini
@@ -18,6 +18,7 @@ build_flags =
     -D TEMPERATURE_CHANNELS_MAX=4             ; if changed, update initialization in main.cpp
     -D THERMOCOUPLE_UPDATE_INTERVAL_MS=100UL  ; how often to read thermocouple
     -D MAX_SAFE_TEMP_C=250U                   ; Max allowed temp, before triggering shutdown
+    -D SAFE_TEMP_HISTERESIS_C=2U              ; Safety temp histeresis. Disarm, if temp drops
     -D MAX_SAFE_TIMEOUT_MS=3000UL             ; Trigger safety shutdown if exceeding the timeout
 
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -17,6 +17,8 @@ build_flags =
     -D SKYDUINO_COMMIT='"abc678def"'
     -D TEMPERATURE_CHANNELS_MAX=4             ; if changed, update initialization in main.cpp
     -D THERMOCOUPLE_UPDATE_INTERVAL_MS=100UL  ; how often to read thermocouple
+    -D MAX_SAFE_TEMP_C=250U                   ; Max allowed temp, before triggering shutdown
+    -D MAX_SAFE_TIMEOUT_MS=3000UL             ; Trigger safety shutdown if exceeding the timeout
 
 
 [env:skyduino-dfu]

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -21,6 +21,7 @@
  */
 extern State state;
 
+cmndAbort   cmnd_handler_abrt = cmndAbort( &state );
 cmndChan    cmnd_handler_chan = cmndChan( &state );
 cmndCool    cmnd_handler_cool = cmndCool( &state );
 cmndDrum    cmnd_handler_drum = cmndDrum( &state );
@@ -38,6 +39,7 @@ static CmndInterp ci( DELIM ); // command interpreter object
 
 void setupCommandHandlers(void) {
     Command* commands[] = {
+        &cmnd_handler_abrt,
         &cmnd_handler_version,
         &cmnd_handler_dfu,
         &cmnd_handler_stat,

--- a/src/commands/handler_skywalker.cpp
+++ b/src/commands/handler_skywalker.cpp
@@ -4,6 +4,7 @@
 #define CMD_COOL    "COOL"
 #define CMD_DRUM    "DRUM"
 #define CMD_OFF     "OFF"
+#define CMD_ABORT   "ABORT"
 
 
 cmndCool::cmndCool(State *state):
@@ -37,4 +38,14 @@ cmndOff::cmndOff(State *state):
 
 void cmndOff::_doCommand(CmndParser *pars) {
     state->commanded.off();
+}
+
+
+cmndAbort::cmndAbort(State *state):
+    Command(CMD_ABORT, state) {
+}
+
+
+void cmndAbort::_doCommand(CmndParser *pars) {
+    state->commanded.abort();
 }

--- a/src/commands/handler_skywalker.cpp
+++ b/src/commands/handler_skywalker.cpp
@@ -36,16 +36,5 @@ cmndOff::cmndOff(State *state):
 
 
 void cmndOff::_doCommand(CmndParser *pars) {
-    ControlBasic* controls[] = {
-        &(state->commanded.cool),
-        &(state->commanded.drum),
-        &(state->commanded.filter),
-        &(state->commanded.heat),
-        &(state->commanded.vent)
-    };
-
-    uint8_t count = sizeof(controls) / sizeof(controls[0]);
-    for (uint8_t i=0; i < count; i++) {
-        controls[i]->off();
-    }
+    state->commanded.off();
 }

--- a/src/commands/handler_skywalker.h
+++ b/src/commands/handler_skywalker.h
@@ -27,4 +27,12 @@ class cmndOff: public Command {
         void _doCommand( CmndParser* pars);
 };
 
+class cmndAbort: public Command {
+    public:
+        cmndAbort(State *state);
+
+    protected:
+        void _doCommand( CmndParser* pars);
+};
+
 #endif // __CMD_SKYWALKER_H

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5,6 +5,7 @@
 #include "state.h"
 #include "logging.h"
 #include "commands.h"
+#include "safemon.h"
 
 
 /*
@@ -13,11 +14,14 @@
  * and commanded roaster status
  */
 State state;
+SafetyMonitor safeMon = SafetyMonitor( &state );
 
 void setup() {
   Serial.begin(115200);
   Serial.setTimeout(100);
   Serial.println(F(VERSION));
+
+  safeMon.begin();
 
   while ( !(state.begin()) ) {
     Serial.println(F("Failed to initialize"));
@@ -33,4 +37,6 @@ void loop() {
   commandsLoopTick();
 
   state.loopTick();
+
+  safeMon.loopTick();
 }

--- a/src/safemon.cpp
+++ b/src/safemon.cpp
@@ -1,6 +1,14 @@
+#include <logging.h>
+
 #include "safemon.h"
 
-#define IS_EXCEEDING(x) ( (!isnan(x)) && (x >= MAX_SAFE_TEMP_C) )
+#define IS_EXCEEDING(x, t) ( (!isnan(x)) && (x >= t) )
+#define IS_EXCEEDING_MAX (_isTempExceedingC(MAX_SAFE_TEMP_C))
+#define IS_EXCEEDING_LOW_MAX ( \
+        _isTempExceedingC( \
+            MAX_SAFE_TEMP_C - SAFE_TEMP_HISTERESIS_C \
+        ))
+
 
 bool SafetyMonitor::begin() {
     if ( !isInitialized ) {
@@ -8,26 +16,166 @@ bool SafetyMonitor::begin() {
         isInitialized = true;
     }
 
-    exceedCounter = 0;
     return true;
 }
 
+
+/**
+ * @brief Handle state transitions for the safety monitor
+ * 
+ * The logic is fairly simple: transition to ARMED state, if the exceed counter is
+ * positive. Transition back to NORMAL, if the exceed counter is 0. Staying long enough
+ * in ARMED state, eventually, from ARMED transition to TRIGGERED state if still
+ * exceeding the temperature.
+ * 
+ * @return true if tick is successfuly handled (always)
+ */
 bool SafetyMonitor::loopTick() {
     if ( !isInitialized ) begin();
 
+    switch ( _monitorState ) {
+    case NORMAL:
+        _handleNormal(); 
+        break;
+
+    case PRE_ARM:
+        _handlePreArm(); 
+        break;
+
+    case ARMED:
+        _handleArmed(); 
+        break;
+
+    case TRIGGERED:
+        _handleTriggered(); 
+        break;
+
+    default:
+        ERRORLN(F("Unknown State"));
+        triggerSafetyAction();
+        break;
+    }
 
     return true;
 }
+
 
 void SafetyMonitor::triggerSafetyAction() {
 }
 
-bool SafetyMonitor::_isTempExceeded() {
-    float tcTemp = _state->reported.getChanTemp(TEMPERATURE_CHANNEL_THERMOCOUPLE);
-    float ntcTemp = _state->reported.getChanTemp(TEMPERATURE_CHANNEL_ROASTER);
+
+/**
+ * @brief Check if any channel exceeds the max safety temperature
+ * 
+ * if none of the temperature channels are avaiable, then return True, better
+ * safe than sorry. However, the NTC channel should always be there, unless
+ * there is a hardware fault.
+ * 
+ * @return true if any temperature channels are exceeding the max temperature
+ *         or if both channels are unavailable
+ */
+bool SafetyMonitor::_isTempExceedingC(float threshold) {
+    float tcTemp = _roasterState->reported.getChanTemp(TEMPERATURE_CHANNEL_THERMOCOUPLE);
+    float ntcTemp = _roasterState->reported.getChanTemp(TEMPERATURE_CHANNEL_ROASTER);
 
     // it temperature reading is not available at all, then better safe than sorry
     bool noTempAtAll = isnan(tcTemp) && isnan(ntcTemp);
 
-    return noTempAtAll || IS_EXCEEDING( tcTemp ) || IS_EXCEEDING( ntcTemp ); 
+    return noTempAtAll
+           || IS_EXCEEDING( tcTemp, threshold )
+           || IS_EXCEEDING( ntcTemp, threshold ); 
+}
+
+
+/**
+ * @brief Transition to NORMAL state
+ */
+void SafetyMonitor::_transitionToNormal() {
+    _monitorState = NORMAL;
+}
+
+
+/**
+ * @brief handle NORMAL state and possible transition to a different -- PRE_ARM
+ *        state
+ */
+void SafetyMonitor::_handleNormal() {
+    if ( IS_EXCEEDING_MAX ) _transitionToPreArm();
+}
+
+
+/**
+ * @brief Transition to PRE_ARM state
+ * 
+ * Does not reset active timer, therefore if bouncing quickly between MAX and MAX-Histereris
+ * may trigger the safety action.
+ */
+void SafetyMonitor::_transitionToPreArm() {
+    _monitorState = PRE_ARM;
+    if ( timer->hasTicked() ) timer->reset();
+}
+
+
+/**
+ * @brief Handle PRE_ARM state
+ * 
+ * May decide dropping back to NORMAL, if the temperature drops.
+ * Or may transition to ARMED state if timer expires while the temp is exceeding the max safe limit.
+ * 
+ */
+void SafetyMonitor::_handlePreArm() {
+    if ( timer->hasTicked() ) {
+        _transitionToArmed();
+    } else if ( !IS_EXCEEDING_LOW_MAX ) {
+        _transitionToNormal();
+    }
+}
+
+
+/**
+ * @brief Transition to ARMED state
+ * 
+ */
+void SafetyMonitor::_transitionToArmed() {
+    _monitorState = ARMED;
+    timer->reset();
+}
+
+
+/**
+ * @brief Handle ARMED state
+ * 
+ * May decide dropping back to NORMAL, if the temperature drops.
+ * Or may transition to ARMED state if timer expires while the temp is exceeding the max safe limit.
+ * 
+ */
+void SafetyMonitor::_handleArmed() {
+    if ( timer->hasTicked() ) {
+        _transitionToTriggered();
+    } else if ( !IS_EXCEEDING_LOW_MAX ) {
+        _transitionToNormal();
+    }
+}
+
+
+/**
+ * @brief Transition to triggered state and effectively call safety action
+ */
+void SafetyMonitor::_transitionToTriggered() {
+    _monitorState = TRIGGERED;
+    _handleTriggered();
+}
+
+
+/**
+ * @brief Trigger safetyAction
+ * 
+ * Trigger saferyAction every MAX_SAFE_TIMEOUT_MS in perpetuity,
+ * until a hardware reset or power reset.
+ */
+void SafetyMonitor::_handleTriggered() {
+    if ( timer->hasTicked() ) {
+        triggerSafetyAction();
+        timer->reset();
+    }
 }

--- a/src/safemon.cpp
+++ b/src/safemon.cpp
@@ -1,19 +1,30 @@
 #include "safemon.h"
 
+#define IS_EXCEEDING(x) ( (!isnan(x)) && (x >= MAX_SAFE_TEMP_C) )
+
 bool SafetyMonitor::begin() {
     if ( !isInitialized ) {
         timer = new TimerMS(MAX_SAFE_TIMEOUT_MS);
         isInitialized = true;
     }
 
+    exceedCounter = 0;
     return true;
 }
 
 bool SafetyMonitor::loopTick() {
     if ( !isInitialized ) begin();
 
+
     return true;
 }
 
 void SafetyMonitor::triggerSafetyAction() {
+}
+
+bool SafetyMonitor::_isTempExceeded() {
+    float tcTemp = _state->reported.getChanTemp(TEMPERATURE_CHANNEL_THERMOCOUPLE);
+    float ntcTemp = _state->reported.getChanTemp(TEMPERATURE_CHANNEL_ROASTER);
+
+    return IS_EXCEEDING( tcTemp ) || IS_EXCEEDING( ntcTemp ); 
 }

--- a/src/safemon.cpp
+++ b/src/safemon.cpp
@@ -60,7 +60,11 @@ bool SafetyMonitor::loopTick() {
 }
 
 
+/**
+ * @brief Trigger abort action for the roaster commanded state
+ */
 void SafetyMonitor::triggerSafetyAction() {
+    this->_roasterState->commanded.abort();
 }
 
 

--- a/src/safemon.cpp
+++ b/src/safemon.cpp
@@ -1,0 +1,19 @@
+#include "safemon.h"
+
+bool SafetyMonitor::begin() {
+    if ( !isInitialized ) {
+        timer = new TimerMS(MAX_SAFE_TIMEOUT_MS);
+        isInitialized = true;
+    }
+
+    return true;
+}
+
+bool SafetyMonitor::loopTick() {
+    if ( !isInitialized ) begin();
+
+    return true;
+}
+
+void SafetyMonitor::triggerSafetyAction() {
+}

--- a/src/safemon.cpp
+++ b/src/safemon.cpp
@@ -64,6 +64,7 @@ bool SafetyMonitor::loopTick() {
  * @brief Trigger abort action for the roaster commanded state
  */
 void SafetyMonitor::triggerSafetyAction() {
+    DEBUG(micros()); DEBUGLN(F(" Triggering Safety Action"));
     this->_roasterState->commanded.abort();
 }
 
@@ -95,6 +96,7 @@ bool SafetyMonitor::_isTempExceedingC(float threshold) {
  * @brief Transition to NORMAL state
  */
 void SafetyMonitor::_transitionToNormal() {
+    DEBUG(micros()); DEBUGLN(F(" Transitioning to Normal state"));
     _monitorState = NORMAL;
 }
 
@@ -115,6 +117,7 @@ void SafetyMonitor::_handleNormal() {
  * may trigger the safety action.
  */
 void SafetyMonitor::_transitionToPreArm() {
+    DEBUG(micros()); DEBUGLN(F(" Transitioning to PRE-ARM state"));
     _monitorState = PRE_ARM;
     if ( timer->hasTicked() ) timer->reset();
 }
@@ -141,6 +144,7 @@ void SafetyMonitor::_handlePreArm() {
  * 
  */
 void SafetyMonitor::_transitionToArmed() {
+    DEBUG(micros()); DEBUGLN(F(" Transitioning to ARM state"));
     _monitorState = ARMED;
     timer->reset();
 }
@@ -166,6 +170,7 @@ void SafetyMonitor::_handleArmed() {
  * @brief Transition to triggered state and effectively call safety action
  */
 void SafetyMonitor::_transitionToTriggered() {
+    DEBUG(micros()); DEBUGLN(F(" Transitioning to Triggered state"));
     _monitorState = TRIGGERED;
     _handleTriggered();
 }

--- a/src/safemon.cpp
+++ b/src/safemon.cpp
@@ -26,5 +26,8 @@ bool SafetyMonitor::_isTempExceeded() {
     float tcTemp = _state->reported.getChanTemp(TEMPERATURE_CHANNEL_THERMOCOUPLE);
     float ntcTemp = _state->reported.getChanTemp(TEMPERATURE_CHANNEL_ROASTER);
 
-    return IS_EXCEEDING( tcTemp ) || IS_EXCEEDING( ntcTemp ); 
+    // it temperature reading is not available at all, then better safe than sorry
+    bool noTempAtAll = isnan(tcTemp) && isnan(ntcTemp);
+
+    return noTempAtAll || IS_EXCEEDING( tcTemp ) || IS_EXCEEDING( ntcTemp ); 
 }

--- a/src/safemon.cpp
+++ b/src/safemon.cpp
@@ -64,7 +64,7 @@ bool SafetyMonitor::loopTick() {
  * @brief Trigger abort action for the roaster commanded state
  */
 void SafetyMonitor::triggerSafetyAction() {
-    DEBUG(micros()); DEBUGLN(F(" Triggering Safety Action"));
+    ERROR(micros()); ERRORLN(F(" Triggering Safety Action"));
     this->_roasterState->commanded.abort();
 }
 

--- a/src/safemon.h
+++ b/src/safemon.h
@@ -2,18 +2,34 @@
 
 #include "state.h"
 
+enum MonitorState {
+    NORMAL,
+    PRE_ARM,
+    ARMED,
+    TRIGGERED
+};
+
+
 class SafetyMonitor {
     public:
-        SafetyMonitor(State *state): _state(state) {};
+        SafetyMonitor(State *state): _roasterState(state) {};
         bool begin();
         bool loopTick();
         void triggerSafetyAction();
     
     private:
-        State   *_state;
-        TimerMS *timer;
-        bool    isInitialized = false;
-        unsigned int exceedCounter = 0;
+        State        *_roasterState;
+        MonitorState _monitorState = NORMAL;
+        TimerMS      *timer;
+        bool         isInitialized = false;
 
-        bool _isTempExceeded();
+        bool _isTempExceedingC(float threshold);
+        void _transitionToNormal();
+        void _handleNormal();
+        void _transitionToPreArm();
+        void _handlePreArm();
+        void _transitionToArmed();
+        void _handleArmed();
+        void _transitionToTriggered();
+        void _handleTriggered();
 };

--- a/src/safemon.h
+++ b/src/safemon.h
@@ -13,4 +13,7 @@ class SafetyMonitor {
         State   *_state;
         TimerMS *timer;
         bool    isInitialized = false;
+        unsigned int exceedCounter = 0;
+
+        bool _isTempExceeded();
 };

--- a/src/safemon.h
+++ b/src/safemon.h
@@ -1,0 +1,11 @@
+#include "state.h"
+
+class SafetyMonitor {
+    public:
+        SafetyMonitor(State *state): _state(state) {};
+        bool loopTick();
+
+    
+    private:
+        State *_state;
+};

--- a/src/safemon.h
+++ b/src/safemon.h
@@ -1,11 +1,16 @@
+#include <tick-timer.h>
+
 #include "state.h"
 
 class SafetyMonitor {
     public:
         SafetyMonitor(State *state): _state(state) {};
+        bool begin();
         bool loopTick();
-
+        void triggerSafetyAction();
     
     private:
-        State *_state;
+        State   *_state;
+        TimerMS *timer;
+        bool    isInitialized = false;
 };

--- a/src/state_commanded.cpp
+++ b/src/state_commanded.cpp
@@ -96,11 +96,21 @@ void StateCommanded::off() {
  * Turn everything off and lock out the controls
  */
 void ControlBasic::abort() {
-    off();
     _abortAction();
+    off();
     this->_isAborted = true;
 }
 
+
+/**
+ * @brief action to perform prior the public abort() method
+ * 
+ * This is a handler for the "pre-abort" actions, called from the public
+ * abort method, giving a chance to do any extra changes, before the conrol
+ * switches off and is locked out from other changes. 
+ */
+void ControlBasic::_abortAction() {
+}
 
 void ControlBasic::on() {
     this->set(100);

--- a/src/state_commanded.cpp
+++ b/src/state_commanded.cpp
@@ -52,6 +52,25 @@ void StateCommanded::printState() {
 }
 
 
+/**
+ * @brief Turn everything off gracefully
+ */
+void StateCommanded::off() {
+    ControlBasic* controls[] = {
+        &cool,
+        &drum,
+        &filter,
+        &heat,
+        &vent
+    };
+
+    uint8_t count = sizeof(controls) / sizeof(controls[0]);
+    for (uint8_t i=0; i < count; i++) {
+        controls[i]->off();
+    }
+}
+
+
 void ControlBasic::on() {
     this->set(100);
 }

--- a/src/state_commanded.cpp
+++ b/src/state_commanded.cpp
@@ -215,9 +215,11 @@ bool ControlHeat::loopTick() {
     {
         if ( isOn() ) {
             // transitioning to ON, set the PWM
+            DEBUG(micros()); DEBUG(F(" loopTick: Setting SSR to ")); DEBUGLN(this->oldValue);
             ControlPWM::_setAction(this->oldValue);
         } else {
             // transitioning to OFF, turn off the relay
+            DEBUG(micros()); DEBUGLN(F(" loopTick: Turning off Heat Relay"));
             this->heatRelay.off();
         }
         isTransitioning = false;
@@ -242,6 +244,7 @@ void ControlHeat::_abortAction() {
         // 50Hz + 1MS
         delay(11);
     }
+    DEBUG(micros()); DEBUGLN(F(" _abort: Turning off Heat relay"));
     this->heatRelay.off();
 
     // double tap: explicitly turn relay off via GPIO
@@ -271,13 +274,16 @@ void ControlHeat::_setAction(uint8_t newValue) {
         // If transitioning from Off to On, then make sure the SSR is off(pwm=0)
         // and turn on the relay now. Next loopTick will turn on the SSR (set the
         // desired PWM)
+        DEBUG(micros()); DEBUGLN(F(" _setAction: Turning off SSR"));
         ControlPWM::_setAction(0);
         if ( newIsOn ) {
             // The state is transitioning to ON
             // turn on the Relay and loopTick will set the new PWM value
+            DEBUG(micros()); DEBUGLN(F(" _setAction: Turning on Heat Relay"));
             this->heatRelay.on();
         }
     } else {
+        DEBUG(micros()); DEBUG(F(" _setAction: Setting SSR to ")); DEBUGLN(newValue);
         ControlPWM::_setAction(newValue);
     }
 }

--- a/src/state_commanded.h
+++ b/src/state_commanded.h
@@ -15,6 +15,7 @@ class ControlBasic {
         bool virtual begin() {return true;};
         void virtual off();
         void virtual on();
+        bool virtual isOn();
         uint8_t virtual get();
         void virtual set(uint8_t value);
         bool virtual loopTick();
@@ -55,6 +56,7 @@ class ControlHeat: public ControlPWM {
         ControlHeat(): ControlPWM(PIN_HEAT, PWM_FREQ_HEAT) {};
         bool begin();
         bool loopTick();
+        void abort();
 
     protected:
         void _setAction(uint8_t value);

--- a/src/state_commanded.h
+++ b/src/state_commanded.h
@@ -78,6 +78,7 @@ class StateCommanded {
         bool begin();
         bool loopTick();
         void printState();
+        void off();
 };
 
 

--- a/src/state_commanded.h
+++ b/src/state_commanded.h
@@ -19,12 +19,16 @@ class ControlBasic {
         uint8_t virtual get();
         void virtual set(uint8_t value);
         bool virtual loopTick();
+        void virtual abort();
 
     private:
         uint8_t         value;
     
     protected:
+        bool _isAborted = false;
         void virtual _setAction(uint8_t value) {};
+        void virtual _abortAction() {};
+
 };
 
 class ControlOnOff: public ControlBasic {
@@ -56,7 +60,6 @@ class ControlHeat: public ControlPWM {
         ControlHeat(): ControlPWM(PIN_HEAT, PWM_FREQ_HEAT) {};
         bool begin();
         bool loopTick();
-        void abort();
 
     protected:
         void _setAction(uint8_t value);
@@ -66,6 +69,7 @@ class ControlHeat: public ControlPWM {
         uint8_t oldValue = 0;
         TimerMS *transitionTimer;
         ControlOnOff heatRelay = ControlOnOff(PIN_HEAT_RELAY);
+        void _abortAction();
 };
 
 
@@ -77,6 +81,7 @@ class StateCommanded {
         ControlOnOff cool   = ControlOnOff(PIN_COOL);
         ControlBasic filter;
 
+        void abort();
         bool begin();
         bool loopTick();
         void printState();

--- a/src/state_commanded.h
+++ b/src/state_commanded.h
@@ -27,7 +27,7 @@ class ControlBasic {
     protected:
         bool _isAborted = false;
         void virtual _setAction(uint8_t value) {};
-        void virtual _abortAction() {};
+        void virtual _abortAction();
 
 };
 

--- a/src/state_reported.cpp
+++ b/src/state_reported.cpp
@@ -139,6 +139,9 @@ void Reported::setChanMapping(uint8_t idx, uint8_t mapping) {
     this->_chanMapping[idx] = mapping;
 }
 
+float Reported::getChanTemp(uint8_t chan) {
+    return this->chanTemp[ chan ];
+}
 
 void Reported::_readNTC() {
     float ntcTemp = ntc.AdcToTempC( analogRead(PIN_NTC) );

--- a/src/state_reported.cpp
+++ b/src/state_reported.cpp
@@ -140,6 +140,12 @@ void Reported::setChanMapping(uint8_t idx, uint8_t mapping) {
 }
 
 float Reported::getChanTemp(uint8_t chan) {
+    if ( chan >= TEMPERATURE_CHANNELS_MAX ) {
+        // this should not happen, but as a precaution
+        // for wrong channels return temperature exceeding safety limits
+        return (MAX_SAFE_TEMP_C + 1);
+    }
+    
     return this->chanTemp[ chan ];
 }
 


### PR DESCRIPTION
If the temperature in one of the channels (Thermocouple Max31855 or NTC) exceeds the maximum temperature 250C for 6s, shut everything off and lock out the controls. A power off reset is required to exit this state.

The 6s is the double  of `MAX_SAFE_TIMEOUT_MS` defined in platformio.io Within this period, if the temperature drops two degrees C -- `SAFE_TEMP_HISTERESIS_C` then the timer is reset.

The safety monitor does require at least one operational temperature channel, either NTC or the Thermocouple. If none are available, then the fault is assumed, and the safety action trigger action is executed.