### PR TITLE
Implement Stepper Driver control for the drum mod

### DIFF
--- a/.github/workflows/Platformio-ci.yaml
+++ b/.github/workflows/Platformio-ci.yaml
@@ -63,6 +63,17 @@ jobs:
             .pio/build/skyduino-dfu/firmware.bin
             .pio/build/skyduino-dfu/firmware.elf
 
+      - name: Build Stepper environment
+        run: pio run -e skyduino-stepper
+
+      - name: upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: Firmware Stepper
+          path: |
+            .pio/build/skyduino-stepper/firmware.bin
+            .pio/build/skyduino-stepper/firmware.elf
+
   UploadAssets:
     name: Upload Assets
     if: ${{ startsWith(github.ref, 'refs/tags/v') }}

--- a/.github/workflows/upload-release-assets.yaml
+++ b/.github/workflows/upload-release-assets.yaml
@@ -15,6 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       firmware_zip: 'Skyduino Firmware-${{ github.ref_name }}.zip'
+      firmware_stepper_zip: 'Skyduino Stepper Firmware-${{ github.ref_name }}.zip'
 
     steps:
       - id: download
@@ -23,7 +24,10 @@ jobs:
           merge-multiple: true
 
       - id: zip_firmware
-        run: zip -r -5 '${{ env.firmware_zip }}' .
+        run: zip -r -5 '${{ env.firmware_zip }}' Firmware
+
+      - id: zip_firmware_stepper
+        run: zip -r -5 '${{ env.firmware_stepper_zip }}' 'Firmware Stepper'
       
       - id: upload_assets
         name: Upload assets
@@ -31,4 +35,5 @@ jobs:
         with:
           files: |
             ${{ env.firmware_zip }}
+            ${{ env.firmware_stepper_zip }}
           generate_release_notes: false

--- a/.github/workflows/upload-release-assets.yaml
+++ b/.github/workflows/upload-release-assets.yaml
@@ -20,8 +20,6 @@ jobs:
     steps:
       - id: download
         uses: actions/download-artifact@v4
-        with:
-          merge-multiple: true
 
       - id: zip_firmware
         run: zip -r -5 '${{ env.firmware_zip }}' Firmware

--- a/README.md
+++ b/README.md
@@ -21,6 +21,19 @@ build firmware yourself (easiest way is to use the [PlatformIO IDE](https://plat
 in [VSCode](https://code.visualstudio.com/download)) or as the last resort, try finding a latest
 artifact in [Github Actions](https://github.com/Skyduino/SkyduinoRoasterController/actions/workflows/Platformio-ci.yaml) run history.
 
+### Stepper drum motor firmware
+The "Firmware Stepper" zip file contains the modified firmware to control the drum
+using a stepper motor. This does require a separate stepper motor driver,
+controlled through **J13 Disp** header, using the following pins:
+
+| Pin Name | Function | Description |
+| --- | --- | --- |
+| SCL | STEP | Step signal to stepper driver |
+| SDA | nEN | Enable signal to driver, low level is active |
+
+The firmware was tested with TMC2209 driver board. You may need to hardwire the direction pin, as this is not controlled at the moment.
+
+
 ## DFU Mode
 
 The board is based on ST32F412RET6 microcontroller, therefore the easiest way to install or

--- a/include/roaster.h
+++ b/include/roaster.h
@@ -38,7 +38,7 @@
 #define PIN_STEPPER_EN   PB7
 #endif  // PIN_STEPPER_EN
 
-#define STEPPER_STEPS_PER_REV 200
+#define STEPPER_STEPS_PER_REV 1500
 #define STEPPER_MAX_RPM       60
 
 #endif  // USE_STEPPER_DRUM

--- a/include/roaster.h
+++ b/include/roaster.h
@@ -27,6 +27,23 @@
 
 #define SPI_BTCS          PA4
 
+// Allow use of DRV8855 stepper motor for drum driving
+#ifdef USE_STEPPER_DRUM
+
+#ifndef PIN_STEPPER_STEP
+#define PIN_STEPPER_STEP PB6
+#endif  // PIN_STEPPER_STEP
+
+#ifndef PIN_STEPPER_EN
+#define PIN_STEPPER_EN   PB7
+#endif  // PIN_STEPPER_EN
+
+#define STEPPER_STEPS_PER_REV 200
+#define STEPPER_MAX_RPM       60
+
+#endif  // USE_STEPPER_DRUM
+
+
 // PWM frequencies Hz
 #define PWM_FREQ_COOL       60
 #define PWM_FREQ_DRUM       60

--- a/include/roaster.h
+++ b/include/roaster.h
@@ -21,7 +21,7 @@
 #define PIN_DATA_TO_RMT   PA10
 #define PIN_DRUM          PA15
 #define PIN_HEAT_RELAY    PB8
-#define PIN_HEAT          PB9
+#define PIN_HEAT          PB9_ALT1
 #define PIN_NTC           PC5
 #define PIN_COOL          PC8
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -32,6 +32,14 @@ upload_protocol = dfu
 extends = skyduino
 
 
+[env:skyduino-stepper]
+extends = skyduino
+build_flags =
+  ${skyduino.build_flags}
+  -D USE_STEPPER_DRUM
+
+
+
 [env:skyduino-debug]
 extends = skyduino
 build_flags =

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -10,6 +10,9 @@
 #include "commands/handler_read.h"
 #include "commands/handler_stat.h"
 #include "commands/handler_skywalker.h"
+#ifdef USE_STEPPER_DRUM
+#include "commands/handler_stepper_drum.h"
+#endif // USE_STEPPER_DRUM
 #include "commands/handler_unit.h"
 #include "commands/handler_version.h"
 
@@ -32,6 +35,10 @@ cmndOT1     cmnd_handler_ot1  = cmndOT1( &state );
 cmndOT2     cmnd_handler_ot2  = cmndOT2( &state );
 cmndRead    cmnd_handler_read = cmndRead( &state );
 cmndStat    cmnd_handler_stat = cmndStat( &state );
+#ifdef USE_STEPPER_DRUM
+cmndSteps   cmnd_handler_steps= cmndSteps( &state );
+cmndMaxRPM  cmnd_handler_rpm  = cmndMaxRPM( &state ); 
+#endif // USE_STEPPER_DRUM
 cmndUnit    cmnd_handler_unit = cmndUnit( &state );
 cmndVersion cmnd_handler_version;
 
@@ -39,6 +46,10 @@ static CmndInterp ci( DELIM ); // command interpreter object
 
 void setupCommandHandlers(void) {
     Command* commands[] = {
+#ifdef USE_STEPPER_DRUM
+        &cmnd_handler_steps,
+        &cmnd_handler_rpm,
+#endif // USE_STEPPER_DRUM
         &cmnd_handler_abrt,
         &cmnd_handler_version,
         &cmnd_handler_dfu,

--- a/src/commands/base.cpp
+++ b/src/commands/base.cpp
@@ -25,9 +25,16 @@ bool Command::doCommand(CmndParser *pars) {
 
 
 ControlCommand::ControlCommand(const char *cmdName, State *state):
-    Command(cmdName, state) {
+    Command(cmdName, state), min(0), max(100) {
 }
 
+ControlCommand::ControlCommand(const char *cmdName,
+                               State *state,
+                               uint32_t clamp_min,
+                               int32_t clamp_max):
+    Command(cmdName, state), min(clamp_min), max(clamp_max) {
+
+}
 
 void ControlCommand::_doCommand(CmndParser *pars)
 {

--- a/src/commands/base.h
+++ b/src/commands/base.h
@@ -21,13 +21,14 @@ class Command : public CmndBase {
 class ControlCommand: public Command {
     public:
         ControlCommand(const char *cmdName, State *state);
+        ControlCommand(const char *cmdName, State *state, uint32_t clamp_min, int32_t clamp_max);
     protected:
         void _doCommand( CmndParser* pars);
         void virtual _handleValue(int32_t value) =0;
 
     private:
-        const int32_t min = 0;
-        const int32_t max = 100;
+        int32_t min;
+        int32_t max;
 };
 
 #endif // __CMD_BASE_H

--- a/src/commands/handler_stepper_drum.cpp
+++ b/src/commands/handler_stepper_drum.cpp
@@ -1,0 +1,40 @@
+#include "state.h"
+#include "handler_stepper_drum.h"
+
+#define CMD_STEPS  "STPR"
+#define CMD_MAXRPM "MXRPM"
+#define MIN_RPM    10
+#define MAX_RPM    120
+
+cmndSteps::cmndSteps(State *state):
+    ControlCommand(CMD_STEPS, state) {
+}
+
+
+void cmndSteps::_handleValue(int32_t value) {
+    if ( value > 0 ) {
+        state->commanded.drum.setStepsPerRevolution( value );
+        Serial.print(F("Setting ")); Serial.print(value);
+        Serial.println(F(" steps per revolution"));
+    }
+}
+
+
+cmndMaxRPM::cmndMaxRPM(State *state):
+    ControlCommand(CMD_MAXRPM, state) {
+}
+
+
+void cmndMaxRPM::_handleValue(int32_t value) {
+    if ( value < MIN_RPM ) {
+        Serial.print(F("Ignoring Minimum rpm, it's below ")); Serial.println(MIN_RPM);
+        return;
+    } 
+    if ( value > MAX_RPM ) {
+        Serial.print(F("Ignoring Maximum rpm, it's above ")); Serial.println(MAX_RPM);
+        return;
+    }
+
+    state->commanded.drum.setMaxRPM( value );
+    Serial.print(F("Setting MAX rpm to ")); Serial.println( value );
+}

--- a/src/commands/handler_stepper_drum.cpp
+++ b/src/commands/handler_stepper_drum.cpp
@@ -1,3 +1,4 @@
+#ifdef USE_STEPPER_DRUM
 #include "state.h"
 #include "handler_stepper_drum.h"
 
@@ -38,3 +39,4 @@ void cmndMaxRPM::_handleValue(int32_t value) {
     state->commanded.drum.setMaxRPM( value );
     Serial.print(F("Setting MAX rpm to ")); Serial.println( value );
 }
+#endif // USE_STEPPER_DRUM

--- a/src/commands/handler_stepper_drum.cpp
+++ b/src/commands/handler_stepper_drum.cpp
@@ -7,7 +7,7 @@
 #define MAX_RPM    120
 
 cmndSteps::cmndSteps(State *state):
-    ControlCommand(CMD_STEPS, state) {
+    ControlCommand(CMD_STEPS, state, 60, 30000) {
 }
 
 
@@ -21,7 +21,7 @@ void cmndSteps::_handleValue(int32_t value) {
 
 
 cmndMaxRPM::cmndMaxRPM(State *state):
-    ControlCommand(CMD_MAXRPM, state) {
+    ControlCommand(CMD_MAXRPM, state, MIN_RPM, MAX_RPM) {
 }
 
 

--- a/src/commands/handler_stepper_drum.h
+++ b/src/commands/handler_stepper_drum.h
@@ -1,0 +1,22 @@
+#ifndef __CMD_STEPPER_H
+#define __CMD_STEPPER_H
+
+#include "base.h"
+
+class cmndSteps : public ControlCommand {
+    public:
+        cmndSteps(State *state);
+
+    protected:
+        void _handleValue(int32_t value);
+};
+
+class cmndMaxRPM : public ControlCommand {
+    public:
+        cmndMaxRPM(State *state);
+
+    protected:
+        void _handleValue(int32_t value);
+};
+
+#endif // __CMD_STEPPER_H

--- a/src/state_commanded.cpp
+++ b/src/state_commanded.cpp
@@ -340,18 +340,18 @@ void ControlDrum::_setAction(uint8_t value) {
     } else {
         this->_enable.on();
     }
-
-    if (NULL == timer) {
-        // was not initialized yet
-        this->begin();
-    } else {
-        this->timer->setPWM(this->channel, this->pin, this->freq, value);
-        this->timer->refresh();
-    }
+    ControlPWM::_setAction( value );
 }
 
 
-void ControlDrum::_abortAction() {
+void ControlDrum::_setPWM(uint8_t value) {
+    DEBUG(micros()); DEBUG(F(" Stepper Drum value: ")); DEBUGLN(value);
+    ControlPWM( value );
+}
+
+
+void ControlDrum::_abortAction()
+{
     this->_drum.abort();
     this->_enable.abort();
 }

--- a/src/state_commanded.cpp
+++ b/src/state_commanded.cpp
@@ -342,6 +342,19 @@ uint32_t ControlDrum::durationFromValue(uint8_t value) {
 }
 
 
+
+/**
+ * @brief convert value (%) into PWM frequence, based on the steps
+ *        per revolution and Max supported rpm. 100% value is Max rpm
+ * @param value Value % of max RPM
+ * @return timer PWM frequency in HZ
+*/ 
+uint32_t ControlDrum::frequencyFromValue(uint8_t value) {
+    uint16_t rpm = ( value * this->_max_rpm ) / 100;
+    return ( rpm * this->_steps_per_rev ) / 60;
+}
+
+
 void ControlDrum::_setAction(uint8_t value) {
     if ( _isAborted ) return;
     this->_drum.set(value);
@@ -359,11 +372,10 @@ void ControlDrum::_setAction(uint8_t value) {
 void ControlDrum::_setPWM(uint8_t value) {
     DEBUG(micros()); DEBUG(F(" Stepper Drum value: ")); DEBUGLN(value);
 
-    uint32_t pwm_freq = this->_steps_per_rev * value / 100;
-    if ( 0 == pwm_freq ) {
-        this->timer->setPWM(channel, pin, _steps_per_rev, 0);
+    if ( 0 == value ) {
+        this->timer->setPWM(channel, pin, frequencyFromValue(100), 0);
     } else {
-        this->timer->setPWM(channel, pin, pwm_freq, 50);
+        this->timer->setPWM(channel, pin, frequencyFromValue(value), 50);
     }
 }
 

--- a/src/state_commanded.cpp
+++ b/src/state_commanded.cpp
@@ -346,11 +346,11 @@ void ControlDrum::_setAction(uint8_t value) {
     if ( _isAborted ) return;
     this->_drum.set(value);
 
-    // Turn the stepper enable pin on or off
+    // Turn the stepper enable pin on or off. DRV8825 is nEN
     if ( 0 == value ) {
-        this->_enable.off();
-    } else {
         this->_enable.on();
+    } else {
+        this->_enable.off();
     }
     ControlPWM::_setAction( value );
 }
@@ -363,7 +363,7 @@ void ControlDrum::_setPWM(uint8_t value) {
     this->timer->setMode(channel, TIMER_OUTPUT_COMPARE_PWM1, pin);
     uint32_t overflow = this->durationFromValue(value);
     this->timer->setOverflow(overflow, MICROSEC_FORMAT);
-    this->timer->setCaptureCompare(channel, 2, MICROSEC_COMPARE_FORMAT);
+    this->timer->setCaptureCompare(channel, 50, PERCENT_COMPARE_FORMAT);
     this->timer->resume();
 }
 

--- a/src/state_commanded.cpp
+++ b/src/state_commanded.cpp
@@ -316,3 +316,43 @@ void ControlHeat::_setAction(uint8_t newValue) {
         ControlPWM::_setAction(newValue);
     }
 }
+
+
+#ifdef USE_STEPPER_DRUM
+bool ControlDrum::begin() {
+    bool isSuccess = true;
+    
+    isSuccess &= ControlPWM::begin();
+    isSuccess &= this->_drum.begin();
+    isSuccess &= this->_enable.begin();
+
+    return isSuccess;
+}
+
+
+void ControlDrum::_setAction(uint8_t value) {
+    if ( _isAborted ) return;
+    this->_drum.set(value);
+
+    // Turn the stepper enable pin on or off
+    if ( 0 == value ) {
+        this->_enable.off();
+    } else {
+        this->_enable.on();
+    }
+
+    if (NULL == timer) {
+        // was not initialized yet
+        this->begin();
+    } else {
+        this->timer->setPWM(this->channel, this->pin, this->freq, value);
+        this->timer->refresh();
+    }
+}
+
+
+void ControlDrum::_abortAction() {
+    this->_drum.abort();
+    this->_enable.abort();
+}
+#endif // USE_STEPPER_DRUM

--- a/src/state_commanded.cpp
+++ b/src/state_commanded.cpp
@@ -342,7 +342,6 @@ uint32_t ControlDrum::durationFromValue(uint8_t value) {
 }
 
 
-
 /**
  * @brief convert value (%) into PWM frequence, based on the steps
  *        per revolution and Max supported rpm. 100% value is Max rpm
@@ -353,6 +352,26 @@ uint32_t ControlDrum::frequencyFromValue(uint8_t value) {
     uint32_t freq = ( value * this->_max_rpm * this->_steps_per_rev ) \
                     / 6000;
     return freq;
+}
+
+
+/**
+ * @brief sets steps per revolution for the stepper drum driver
+ * @param steps number of steps for a complete revolution
+ */
+void ControlDrum::setStepsPerRevolution(uint16_t steps) {
+    this->_steps_per_rev = steps;
+    this->set( this->get() );
+}
+
+
+/**
+ * @brief sets max RPM for the stepper driver
+ * @param rpm -- max rpm
+ */
+void ControlDrum::setMaxRPM(uint8_t rpm) {
+    this->_max_rpm = rpm;
+    this->set( this->get() );
 }
 
 

--- a/src/state_commanded.cpp
+++ b/src/state_commanded.cpp
@@ -365,14 +365,6 @@ void ControlDrum::_setPWM(uint8_t value) {
     } else {
         this->timer->setPWM(channel, pin, pwm_freq, 50);
     }
-    return;
-
-    PinName pin = digitalPinToPinName( this->pin );
-    this->timer->setMode(channel, TIMER_OUTPUT_COMPARE_PWM1, pin);
-    uint32_t overflow = this->durationFromValue(value);
-    this->timer->setOverflow(overflow, MICROSEC_FORMAT);
-    this->timer->setCaptureCompare(channel, 50, PERCENT_COMPARE_FORMAT);
-    this->timer->resume();
 }
 
 

--- a/src/state_commanded.cpp
+++ b/src/state_commanded.cpp
@@ -350,8 +350,9 @@ uint32_t ControlDrum::durationFromValue(uint8_t value) {
  * @return timer PWM frequency in HZ
 */ 
 uint32_t ControlDrum::frequencyFromValue(uint8_t value) {
-    uint16_t rpm = ( value * this->_max_rpm ) / 100;
-    return ( rpm * this->_steps_per_rev ) / 60;
+    uint32_t freq = ( value * this->_max_rpm * this->_steps_per_rev ) \
+                    / 6000;
+    return freq;
 }
 
 

--- a/src/state_commanded.cpp
+++ b/src/state_commanded.cpp
@@ -322,9 +322,9 @@ void ControlHeat::_setAction(uint8_t newValue) {
 bool ControlDrum::begin() {
     bool isSuccess = true;
     
-    isSuccess &= ControlPWM::begin();
-    isSuccess &= this->_drum.begin();
     isSuccess &= this->_enable.begin();
+    isSuccess &= this->_drum.begin();
+    isSuccess &= ControlPWM::begin();
 
     return isSuccess;
 }
@@ -358,6 +358,14 @@ void ControlDrum::_setAction(uint8_t value) {
 
 void ControlDrum::_setPWM(uint8_t value) {
     DEBUG(micros()); DEBUG(F(" Stepper Drum value: ")); DEBUGLN(value);
+
+    uint32_t pwm_freq = this->_steps_per_rev * value / 100;
+    if ( 0 == pwm_freq ) {
+        this->timer->setPWM(channel, pin, _steps_per_rev, 0);
+    } else {
+        this->timer->setPWM(channel, pin, pwm_freq, 50);
+    }
+    return;
 
     PinName pin = digitalPinToPinName( this->pin );
     this->timer->setMode(channel, TIMER_OUTPUT_COMPARE_PWM1, pin);

--- a/src/state_commanded.cpp
+++ b/src/state_commanded.cpp
@@ -361,8 +361,9 @@ void ControlDrum::_setPWM(uint8_t value) {
 
     PinName pin = digitalPinToPinName( this->pin );
     this->timer->setMode(channel, TIMER_OUTPUT_COMPARE_PWM1, pin);
-    this->timer->setOverflow(this->freq, HERTZ_FORMAT);
-    this->timer->setCaptureCompare(channel, value, PERCENT_COMPARE_FORMAT);
+    uint32_t overflow = this->durationFromValue(value);
+    this->timer->setOverflow(overflow, MICROSEC_FORMAT);
+    this->timer->setCaptureCompare(channel, 2, MICROSEC_COMPARE_FORMAT);
     this->timer->resume();
 }
 

--- a/src/state_commanded.cpp
+++ b/src/state_commanded.cpp
@@ -346,7 +346,7 @@ void ControlDrum::_setAction(uint8_t value) {
 
 void ControlDrum::_setPWM(uint8_t value) {
     DEBUG(micros()); DEBUG(F(" Stepper Drum value: ")); DEBUGLN(value);
-    ControlPWM( value );
+    ControlPWM::_setPWM( value );
 }
 
 

--- a/src/state_commanded.cpp
+++ b/src/state_commanded.cpp
@@ -373,10 +373,11 @@ void ControlDrum::_setAction(uint8_t value) {
 void ControlDrum::_setPWM(uint8_t value) {
     DEBUG(micros()); DEBUG(F(" Stepper Drum value: ")); DEBUGLN(value);
 
-    if ( 0 == value ) {
-        this->timer->setPWM(channel, pin, frequencyFromValue(100), 0);
+    uint32_t freq = frequencyFromValue(value);
+    if ( 0 == freq ) {
+        this->timer->pause();
     } else {
-        this->timer->setPWM(channel, pin, frequencyFromValue(value), 50);
+        this->timer->setPWM(channel, pin, freq, 50);
     }
 }
 

--- a/src/state_commanded.cpp
+++ b/src/state_commanded.cpp
@@ -179,7 +179,7 @@ void ControlOnOff::_setAction(uint8_t value) {
 }
 
 
-ControlPWM::ControlPWM(uint8_t pin, uint32_t freq): ControlOnOff(pin) {
+ControlPWM::ControlPWM(uint32_t pin, uint32_t freq): ControlOnOff(pin) {
     this->freq = freq;
     this->timer = NULL;
 }

--- a/src/state_commanded.h
+++ b/src/state_commanded.h
@@ -33,17 +33,17 @@ class ControlBasic {
 
 class ControlOnOff: public ControlBasic {
     public:
-        ControlOnOff(uint8_t pin): pin(pin) {};
+        ControlOnOff(uint32_t pin): pin(pin) {};
         bool begin();
 
     protected:
-        const uint8_t   pin;
+        const uint32_t pin;
         void _setAction(uint8_t value);
 };
 
 class ControlPWM: public ControlOnOff {
     public:
-        ControlPWM(uint8_t pin, uint32_t freq);
+        ControlPWM(uint32_t pin, uint32_t freq);
         bool begin();
 
     protected:

--- a/src/state_commanded.h
+++ b/src/state_commanded.h
@@ -80,6 +80,7 @@ class ControlDrum : public ControlPWM {
             _max_rpm( STEPPER_MAX_RPM ) {};
         bool     begin();
         uint32_t durationFromValue(uint8_t value);
+        uint32_t frequencyFromValue(uint8_t value);
 
     protected:
         void _setAction(uint8_t value);

--- a/src/state_commanded.h
+++ b/src/state_commanded.h
@@ -81,6 +81,8 @@ class ControlDrum : public ControlPWM {
         bool     begin();
         uint32_t durationFromValue(uint8_t value);
         uint32_t frequencyFromValue(uint8_t value);
+        void     setStepsPerRevolution(uint16_t steps);
+        void     setMaxRPM(uint8_t rpm);
 
     protected:
         void _setAction(uint8_t value);

--- a/src/state_commanded.h
+++ b/src/state_commanded.h
@@ -72,12 +72,35 @@ class ControlHeat: public ControlPWM {
         void _abortAction();
 };
 
+#ifdef USE_STEPPER_DRUM
+class ControlDrum : public ControlPWM {
+    public:
+        ControlDrum(): ControlPWM( PIN_STEPPER_STEP, 200 ),
+            _steps_per_rev( STEPPER_STEPS_PER_REV ),
+            _max_rpm( STEPPER_MAX_RPM ) {};
+        bool begin();
+
+    protected:
+        void _setAction(uint8_t value);
+    
+    private:
+        uint16_t      _steps_per_rev;
+        uint8_t       _max_rpm;
+        ControlOnOff  _enable = ControlOnOff( PIN_STEPPER_EN );
+        ControlPWM    _drum   = ControlPWM( PIN_DRUM, PWM_FREQ_DRUM );
+        void _abortAction();
+};
+#endif // USE_STEPPER_DRUM
 
 class StateCommanded {
     public:
         ControlHeat heat;
         ControlPWM vent     = ControlPWM(PIN_EXHAUST, PWM_FREQ_EXHAUST);
+#ifdef USE_STEPPER_DRUM
+        ControlDrum drum;
+#else  // USE_STEPPER_DRUM
         ControlPWM drum     = ControlPWM(PIN_DRUM, PWM_FREQ_DRUM);
+#endif // USE_STEPPER_DRUM
         ControlOnOff cool   = ControlOnOff(PIN_COOL);
         ControlBasic filter;
 

--- a/src/state_commanded.h
+++ b/src/state_commanded.h
@@ -84,11 +84,12 @@ class ControlDrum : public ControlPWM {
         void _setAction(uint8_t value);
     
     private:
-        uint16_t      _steps_per_rev;
-        uint8_t       _max_rpm;
-        ControlOnOff  _enable = ControlOnOff( PIN_STEPPER_EN );
-        ControlPWM    _drum   = ControlPWM( PIN_DRUM, PWM_FREQ_DRUM );
-        void _abortAction();
+        uint16_t     _steps_per_rev;
+        uint8_t      _max_rpm;
+        ControlOnOff _enable = ControlOnOff( PIN_STEPPER_EN );
+        ControlPWM   _drum   = ControlPWM( PIN_DRUM, PWM_FREQ_DRUM );
+        void virtual _setPWM(uint8_t value);
+        void         _abortAction();
 };
 #endif // USE_STEPPER_DRUM
 

--- a/src/state_commanded.h
+++ b/src/state_commanded.h
@@ -78,7 +78,8 @@ class ControlDrum : public ControlPWM {
         ControlDrum(): ControlPWM( PIN_STEPPER_STEP, 200 ),
             _steps_per_rev( STEPPER_STEPS_PER_REV ),
             _max_rpm( STEPPER_MAX_RPM ) {};
-        bool begin();
+        bool     begin();
+        uint32_t durationFromValue(uint8_t value);
 
     protected:
         void _setAction(uint8_t value);


### PR DESCRIPTION
Control a stepper driver. This was tested with TMC2209 driver and there are two signals on **J13 Disp** Header used to control the stepper.

 Pin Name | Function | Description |
| --- | --- | --- |
| SCL | STEP | Step signal to stepper driver |
| SDA | nEN | Enable signal to driver, low level is active |

Two additional commands are implemented, to set the number of the steps per single drum revolution and max RPM. 
The default is 1500 Steps per revolution, macro `STEPPER_STEPS_PER_REV` in `include/roaster.h` If you need to change it,
either compile your firmware or set the number of the steps using the serial command. You would have to do it on each artisan start, e.g. in Artisan Config -> Events, on the `Config`, for the default button `RESET` make it to issue a `SERIAL COMMAND` with `OT1;0\\r\\nDRUM;0\\r\\nSTPR;1000` Value, to set `1000` Steps per revolution.

The following two new commands are implemented:

| Command | Format | Example | Description |
| --- | --- | --- | --- |
| STPR | STPR;{NUM} | STPR;1000 | Set the steps per revolutio to {NUM} |
| MXRPM | MXRPM;{NUM} | MXRPM;60 | Set the maximum number of RPMs for drum at 100% speed. Min 10, Max: 120 |
