### PR TITLE
Make stepper configuration persistent

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,15 @@ controlled through **J13 Disp** header, using the following pins:
 
 The firmware was tested with TMC2209 driver board. You may need to hardwire the direction pin, as this is not controlled at the moment.
 
+Depending on the stepper motor and configured micro-step resolution of the stepper
+driver, you need to configure how many steps are needed for the full revolution.
+The firmware default is 1600 steps: 200 motor steps * 8 microstep configuration of TMC2209, when MS0 & MS1 pins are left floating.
+You can configure the number of steps with `STPR=1600` Serial command.
+The setting is persistent, unless the device is fully erased or there are
+incompatible firmware change.
+
+Beside steps per revolution, you can change the max RPM for the drum with `MXRPM=60` command. This corresponds to 60 RPMs when drum speed is set to 100%
+
 
 ## DFU Mode
 

--- a/include/roaster.h
+++ b/include/roaster.h
@@ -38,7 +38,7 @@
 #define PIN_STEPPER_EN   PB7
 #endif  // PIN_STEPPER_EN
 
-#define STEPPER_STEPS_PER_REV 1500
+#define STEPPER_STEPS_PER_REV 1600
 #define STEPPER_MAX_RPM       60
 
 #endif  // USE_STEPPER_DRUM

--- a/include/state.h
+++ b/include/state.h
@@ -60,7 +60,9 @@ class Status {
 
 class State {
     public:
-        State( EepromSettings *nvmSettings ): nvmSettings(nvmSettings) {}
+        State( EepromSettings *nvmSettings ):
+            commanded(StateCommanded(nvmSettings)),
+            nvmSettings(nvmSettings) {};
         StateCommanded  commanded;
         Reported        reported = Reported(&cfg);
         Config          cfg;

--- a/src/commands/handler_stepper_drum.cpp
+++ b/src/commands/handler_stepper_drum.cpp
@@ -15,6 +15,8 @@ cmndSteps::cmndSteps(State *state):
 void cmndSteps::_handleValue(int32_t value) {
     if ( value > 0 ) {
         state->commanded.drum.setStepsPerRevolution( value );
+        state->nvmSettings->settings.stepsPerRevolution = value;
+        state->nvmSettings->markDirty();
         Serial.print(F("Setting ")); Serial.print(value);
         Serial.println(F(" steps per revolution"));
     }
@@ -37,6 +39,8 @@ void cmndMaxRPM::_handleValue(int32_t value) {
     }
 
     state->commanded.drum.setMaxRPM( value );
+    state->nvmSettings->settings.stepsMaxRpm = value;
+    state->nvmSettings->markDirty();
     Serial.print(F("Setting MAX rpm to ")); Serial.println( value );
 }
 #endif // USE_STEPPER_DRUM

--- a/src/eeprom_settings.cpp
+++ b/src/eeprom_settings.cpp
@@ -9,8 +9,8 @@
 /**
  * @brief initialize the Eeprom settings container. Load from eeprom
  *        and initialize the defaults if eeprom data is garbage
- */ 
-bool EepromSettings::begin() {
+ */
+EepromSettings::EepromSettings(const t_Settings *eeprom): defaultSettings(eeprom) {
     EEPROM.get(EEPROM_SETTINGS_ADDR, settings);
     uint16_t crc = calcCRC16((uint8_t *) &settings, offsetof(t_Settings, crc16));
     if ( (settings.crc16 != crc) || (settings.eepromMagic != EEPROM_SETTINGS_MAGIC) )
@@ -20,8 +20,6 @@ bool EepromSettings::begin() {
         memcpy_P(&settings, this->defaultSettings, sizeof(t_Settings));
         this->save();
     }
-
-    return true;
 }
 
 

--- a/src/eeprom_settings.cpp
+++ b/src/eeprom_settings.cpp
@@ -42,8 +42,14 @@ bool EepromSettings::loopTick() {
  * @brief print current eeprom settings
  */
 void EepromSettings::print() {
-    Serial.print(F("Power On count: "));
+    Serial.print(F("NVM Power On count: "));
     Serial.println(this->settings.counters.powerOnResets);
+#ifdef USE_STEPPER_DRUM
+    Serial.print(F("NVM Stepper driver steps per revolution: "));
+    Serial.println(this->settings.stepsPerRevolution);
+    Serial.print(F("NVM Stepper driver Max RPM: "));
+    Serial.println(this->settings.stepsMaxRpm);
+#endif  // USE_STEPPER_DRUM
 }
 
 /**

--- a/src/eeprom_settings.h
+++ b/src/eeprom_settings.h
@@ -29,8 +29,7 @@ class EepromSettings {
     public:
         t_Settings settings;
 
-        EepromSettings(const t_Settings *eeprom): defaultSettings(eeprom) {};
-        bool begin();
+        EepromSettings(const t_Settings *eeprom);
         bool loopTick();
         void markDirty();
         void print();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -40,7 +40,6 @@ void setup() {
   Serial.setTimeout(100);
   Serial.println(F(VERSION));
 
-  nvmSettings.begin();
   if (__HAL_RCC_GET_FLAG(RCC_FLAG_BORRST)) {
       nvmSettings.settings.counters.powerOnResets++;
       nvmSettings.markDirty();

--- a/src/state_commanded.h
+++ b/src/state_commanded.h
@@ -102,17 +102,25 @@ class ControlDrum : public ControlPWM {
 
 class StateCommanded {
     public:
-        StateCommanded(EepromSettings *nvmSettings): _nvmSettings(nvmSettings) {};
-        ControlHeat heat;
-        ControlPWM vent     = ControlPWM(PIN_EXHAUST, PWM_FREQ_EXHAUST);
+        StateCommanded(EepromSettings *nvm):
+            vent(ControlPWM(PIN_EXHAUST, PWM_FREQ_EXHAUST)),
 #ifdef USE_STEPPER_DRUM
-        ControlDrum drum    = ControlDrum(
-            _nvmSettings->settings.stepsPerRevolution,
-            _nvmSettings->settings.stepsMaxRpm);
+            drum(ControlDrum(
+                nvm->settings.stepsPerRevolution,
+                nvm->settings.stepsMaxRpm)),
 #else  // USE_STEPPER_DRUM
-        ControlPWM drum     = ControlPWM(PIN_DRUM, PWM_FREQ_DRUM);
+            drum(ControlPWM(PIN_DRUM, PWM_FREQ_DRUM)),
 #endif // USE_STEPPER_DRUM
-        ControlOnOff cool   = ControlOnOff(PIN_COOL);
+            cool(ControlOnOff(PIN_COOL)),
+            _nvmSettings(nvm) {};
+        ControlHeat heat;
+        ControlPWM vent;
+#ifdef USE_STEPPER_DRUM
+        ControlDrum drum;
+#else  // USE_STEPPER_DRUM
+        ControlPWM drum;
+#endif // USE_STEPPER_DRUM
+        ControlOnOff cool;
         ControlBasic filter;
 
         void abort();

--- a/src/state_commanded.h
+++ b/src/state_commanded.h
@@ -75,9 +75,12 @@ class ControlHeat: public ControlPWM {
 #ifdef USE_STEPPER_DRUM
 class ControlDrum : public ControlPWM {
     public:
-        ControlDrum(): ControlPWM( PIN_STEPPER_STEP, 200 ),
-            _steps_per_rev( STEPPER_STEPS_PER_REV ),
-            _max_rpm( STEPPER_MAX_RPM ) {};
+        ControlDrum(
+            uint16_t stepsPR = STEPPER_STEPS_PER_REV,
+            uint8_t maxRPM = STEPPER_MAX_RPM):
+                ControlPWM( PIN_STEPPER_STEP, 200 ),
+                _steps_per_rev( stepsPR ),
+                _max_rpm( maxRPM ) {};
         bool     begin();
         uint32_t durationFromValue(uint8_t value);
         uint32_t frequencyFromValue(uint8_t value);
@@ -99,10 +102,13 @@ class ControlDrum : public ControlPWM {
 
 class StateCommanded {
     public:
+        StateCommanded(EepromSettings *nvmSettings): _nvmSettings(nvmSettings) {};
         ControlHeat heat;
         ControlPWM vent     = ControlPWM(PIN_EXHAUST, PWM_FREQ_EXHAUST);
 #ifdef USE_STEPPER_DRUM
-        ControlDrum drum;
+        ControlDrum drum    = ControlDrum(
+            _nvmSettings->settings.stepsPerRevolution,
+            _nvmSettings->settings.stepsMaxRpm);
 #else  // USE_STEPPER_DRUM
         ControlPWM drum     = ControlPWM(PIN_DRUM, PWM_FREQ_DRUM);
 #endif // USE_STEPPER_DRUM
@@ -118,6 +124,7 @@ class StateCommanded {
         void setControlToArtisan(bool value = true);
 
     protected:
+        EepromSettings *_nvmSettings;
         bool _isArtisanInControl = false;
 };
 


### PR DESCRIPTION
Leverage new non-volatile memory system framework to make stepper configuration persistent.
The number of the steps per revolution (configured with `STPR;1600` command) and stepper max RPM (configured with `mxrpm;60` command) are persisted across the reboots.

Also, update the default number of steps per revolution to 1600, which is 200 motor steps time 8 microsteps of TMC2209 when `MS1` & `MS0` pins are left floating.