### PR TITLE
Configurable Max Safety temp

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ The following symbols are used for the `Separator` value:
 | READ | READ | READ | Requests current temperature readings on all active channels. Response from the device is the ambient temperature followed by a comma separated list of temperatures in current active units in logical channel order: ambient,chan1,chan2,chan3,chan4, followed up by Heater cyty cycle (0 - 100%) and Exhaust Fan duty cycle |
 | STAT | STAT | STAT | This is an undocumented command. It should print the internal statistics, but currently does not work as expected |
 | STPR | STPR;{NUM} | STPR;1000 | Set the steps per revolutio to {NUM}. This command is only supported for the "Stepper" firmware. |
+| MAXTEMP | MAXTEMP;{NUM} | MAXTEMP;250 | Set the safety temperature threshold in °C The new threshold is activated upon next reboot: Power Off and USB-C disconnect |
 | MXRPM | MXRPM;{NUM} | MXRPM;60 | Set the maximum number of RPMs for drum at 100% speed. Min 10, Max: 120. This command is only supported for the "Stepper" firmware. |
 | UNIT | UNIT;U | UNIT;C<br>UNIT;F | Change the temperature unit of measurement to C or F |
 | VERSION | VERSION | VERSION | Print the controller firmware version |

--- a/lib/cmndproc/include/cmndproc.h
+++ b/lib/cmndproc/include/cmndproc.h
@@ -58,7 +58,7 @@
 #endif
 
 #define MAX_TOKENS 5  // maximum number of tokens in a command line
-#define MAX_TOKEN_LEN 5  // max characters read per token (input may be longer)
+#define MAX_TOKEN_LEN 7  // max characters read per token (input may be longer)
 #define MAX_CMND_LEN 40 // max overall characters in a command line
 #define MAX_DLMTR 4 // max number of delimiter characters
 #define MAX_RESULT_LEN 9 // max length of result string sent back to caller

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -39,6 +39,7 @@ cmndStat    cmnd_handler_stat = cmndStat( &state );
 cmndSteps   cmnd_handler_steps= cmndSteps( &state );
 cmndMaxRPM  cmnd_handler_rpm  = cmndMaxRPM( &state ); 
 #endif // USE_STEPPER_DRUM
+cmndMaxTemp cmnd_handler_maxt = cmndMaxTemp( &state );
 cmndUnit    cmnd_handler_unit = cmndUnit( &state );
 cmndVersion cmnd_handler_version;
 
@@ -50,6 +51,7 @@ void setupCommandHandlers(void) {
         &cmnd_handler_steps,
         &cmnd_handler_rpm,
 #endif // USE_STEPPER_DRUM
+        &cmnd_handler_maxt,
         &cmnd_handler_abrt,
         &cmnd_handler_version,
         &cmnd_handler_dfu,

--- a/src/commands/handler_skywalker.cpp
+++ b/src/commands/handler_skywalker.cpp
@@ -5,6 +5,7 @@
 #define CMD_DRUM    "DRUM"
 #define CMD_OFF     "OFF"
 #define CMD_ABORT   "ABORT"
+#define CMD_MAXTEMP "MAXTEMP"
 
 
 cmndCool::cmndCool(State *state):
@@ -50,3 +51,19 @@ cmndAbort::cmndAbort(State *state):
 void cmndAbort::_doCommand(CmndParser *pars) {
     state->commanded.abort();
 }
+
+
+cmndMaxTemp::cmndMaxTemp(State *state):
+    ControlCommand(CMD_MAXTEMP, state, 60, 300) {
+}
+
+
+void cmndMaxTemp::_handleValue(int32_t value) {
+    if ( value > 0 ) {
+        state->nvmSettings->settings.maxSafeTempC = value;
+        state->nvmSettings->markDirty();
+        Serial.print(F("Setting ")); Serial.print(value);
+        Serial.println(F(" C as the maximum safety temperature at next reboot"));
+    }
+}
+

--- a/src/commands/handler_skywalker.h
+++ b/src/commands/handler_skywalker.h
@@ -35,4 +35,13 @@ class cmndAbort: public Command {
         void _doCommand( CmndParser* pars);
 };
 
+class cmndMaxTemp : public ControlCommand {
+    public:
+        cmndMaxTemp(State *state);
+
+    protected:
+        void _handleValue(int32_t value);
+};
+
+
 #endif // __CMD_SKYWALKER_H

--- a/src/eeprom_settings.cpp
+++ b/src/eeprom_settings.cpp
@@ -48,6 +48,8 @@ void EepromSettings::print() {
     Serial.print(F("NVM Stepper driver Max RPM: "));
     Serial.println(this->settings.stepsMaxRpm);
 #endif  // USE_STEPPER_DRUM
+    Serial.print(F("NVM Safety Temperature Threshold C: "));
+    Serial.println(this->settings.maxSafeTempC);
 }
 
 /**

--- a/src/eeprom_settings.h
+++ b/src/eeprom_settings.h
@@ -18,7 +18,7 @@ typedef struct {
     uint8_t    stepsMaxRpm;
 #endif  // USE_STEPPER_DRUM
 
-    uint16_t   maxSafeTempC;
+    int16_t    maxSafeTempC;
     uint16_t   pwmCoolHz;
     uint16_t   pwmDrumHz;
     uint16_t   pwmExhaustHz;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -38,7 +38,7 @@ PROGMEM const static t_Settings nvmSettingsStorage = {
  */
 EepromSettings nvmSettings = EepromSettings( &nvmSettingsStorage );
 State state = State( &nvmSettings );
-SafetyMonitor safeMon = SafetyMonitor( &state );
+SafetyMonitor safeMon = SafetyMonitor( &state, nvmSettings.settings.maxSafeTempC );
 SkywalkerRemoteComm skwRemoteComm = SkywalkerRemoteComm( &state );
 
 void setup() {

--- a/src/safemon.cpp
+++ b/src/safemon.cpp
@@ -3,10 +3,10 @@
 #include "safemon.h"
 
 #define IS_EXCEEDING(x, t) ( (!isnan(x)) && (x >= t) )
-#define IS_EXCEEDING_MAX (_isTempExceedingC(MAX_SAFE_TEMP_C))
+#define IS_EXCEEDING_MAX (_isTempExceedingC(this->_maxTemp))
 #define IS_EXCEEDING_LOW_MAX ( \
         _isTempExceedingC( \
-            MAX_SAFE_TEMP_C - SAFE_TEMP_HISTERESIS_C \
+            (this->_maxTemp) - SAFE_TEMP_HISTERESIS_C \
         ))
 
 

--- a/src/safemon.h
+++ b/src/safemon.h
@@ -12,16 +12,19 @@ enum MonitorState {
 
 class SafetyMonitor {
     public:
-        SafetyMonitor(State *state): _roasterState(state) {};
+        SafetyMonitor(State *state, int16_t maxTempC=MAX_SAFE_TEMP_C):
+            _roasterState(state),
+            _maxTemp(maxTempC) {};
         bool begin();
         bool loopTick();
         void triggerSafetyAction();
     
     private:
-        State        *_roasterState;
-        MonitorState _monitorState = NORMAL;
-        TimerMS      *timer;
-        bool         isInitialized = false;
+        State         *_roasterState;
+        MonitorState  _monitorState = NORMAL;
+        TimerMS       *timer;
+        const int16_t _maxTemp;
+        bool          isInitialized = false;
 
         bool _isTempExceedingC(float threshold);
         void _transitionToNormal();


### PR DESCRIPTION
Make the maximum safety temperature configurable. If the bean temperature channel (may be affected by the `CHAN` command) exceeds the max safety temperature threshold.

The new command is `MAXTEMP;285` set the safety temperature threshold, effective after next reboot. 