### PR TITLE
Track how many times the safety monitor was triggered

### DIFF
--- a/include/state.h
+++ b/include/state.h
@@ -11,6 +11,7 @@
 #include "state_statistics.h"
 #include "ntc.h"
 
+using callback_t = std::function<void(void)>;
 
 class Config {
     public:

--- a/src/eeprom_settings.cpp
+++ b/src/eeprom_settings.cpp
@@ -52,6 +52,16 @@ void EepromSettings::print() {
     Serial.println(this->settings.maxSafeTempC);
 }
 
+
+/**
+ * @brief Increment safety counter
+ */
+void EepromSettings::incSafetyCounter() {
+    this->settings.counters.safetyTriggers++;
+    this->markDirty();
+}
+
+
 /**
  * @brief save the eeprom container
  */

--- a/src/eeprom_settings.cpp
+++ b/src/eeprom_settings.cpp
@@ -42,6 +42,8 @@ bool EepromSettings::loopTick() {
 void EepromSettings::print() {
     Serial.print(F("NVM Power On count: "));
     Serial.println(this->settings.counters.powerOnResets);
+    Serial.print(F("NVM Safety triggered count: "));
+    Serial.println(this->settings.counters.safetyTriggers);
 #ifdef USE_STEPPER_DRUM
     Serial.print(F("NVM Stepper driver steps per revolution: "));
     Serial.println(this->settings.stepsPerRevolution);

--- a/src/eeprom_settings.h
+++ b/src/eeprom_settings.h
@@ -39,6 +39,7 @@ class EepromSettings {
         bool loopTick();
         void markDirty();
         void print();
+        void incSafetyCounter();
 
     private:
         TimerMS          timer = TimerMS(EEPROM_SAVE_TIME_MS); 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -38,7 +38,10 @@ PROGMEM const static t_Settings nvmSettingsStorage = {
  */
 EepromSettings nvmSettings = EepromSettings( &nvmSettingsStorage );
 State state = State( &nvmSettings );
-SafetyMonitor safeMon = SafetyMonitor( &state, nvmSettings.settings.maxSafeTempC );
+SafetyMonitor safeMon = SafetyMonitor(
+                            &state,
+                            nvmSettings.settings.maxSafeTempC,
+                            std::bind(&EepromSettings::incSafetyCounter, &nvmSettings));
 SkywalkerRemoteComm skwRemoteComm = SkywalkerRemoteComm( &state );
 
 void setup() {

--- a/src/safemon.cpp
+++ b/src/safemon.cpp
@@ -171,6 +171,7 @@ void SafetyMonitor::_handleArmed() {
  */
 void SafetyMonitor::_transitionToTriggered() {
     DEBUG(micros()); DEBUGLN(F(" Transitioning to Triggered state"));
+    if ( incCounter ) incCounter();
     _monitorState = TRIGGERED;
     _handleTriggered();
 }

--- a/src/safemon.h
+++ b/src/safemon.h
@@ -2,6 +2,8 @@
 
 #include "state.h"
 
+using callback_t = std::function<void()>;
+
 enum MonitorState {
     NORMAL,
     PRE_ARM,
@@ -12,9 +14,12 @@ enum MonitorState {
 
 class SafetyMonitor {
     public:
-        SafetyMonitor(State *state, int16_t maxTempC=MAX_SAFE_TEMP_C):
+        SafetyMonitor(State *state,
+                      int16_t maxTempC=MAX_SAFE_TEMP_C,
+                      callback_t callback = NULL):
             _roasterState(state),
-            _maxTemp(maxTempC) {};
+            _maxTemp(maxTempC),
+            incCounter(callback) {};
         bool begin();
         bool loopTick();
         void triggerSafetyAction();
@@ -35,4 +40,5 @@ class SafetyMonitor {
         void _handleArmed();
         void _transitionToTriggered();
         void _handleTriggered();
+        callback_t incCounter;
 };

--- a/src/safemon.h
+++ b/src/safemon.h
@@ -2,8 +2,6 @@
 
 #include "state.h"
 
-using callback_t = std::function<void()>;
-
 enum MonitorState {
     NORMAL,
     PRE_ARM,


### PR DESCRIPTION
Any time the roaster enters into the safe mode, increment the counter and store it in persistent memory.