### PR TITLE
Track reset count

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ The following symbols are used for the `Separator` value:
 | OT1 | OT1;pp | OT1;50 | where `pp` is the % duty cycle for the heater |
 | OT2 | OT2;pp | OT2;50 | where `pp` is the % duty cycle for the exhause air fan |
 | READ | READ | READ | Requests current temperature readings on all active channels. Response from the device is the ambient temperature followed by a comma separated list of temperatures in current active units in logical channel order: ambient,chan1,chan2,chan3,chan4, followed up by Heater cyty cycle (0 - 100%) and Exhaust Fan duty cycle |
+| RESET | RESET | RESET | Generate the RESET challenge. Software resets the board. The command prompts you a challenge and works similarly to the DFU command |
 | STAT | STAT | STAT | This is an undocumented command. It should print the internal statistics, but currently does not work as expected |
 | STPR | STPR;{NUM} | STPR;1000 | Set the steps per revolutio to {NUM}. This command is only supported for the "Stepper" firmware. |
 | MAXTEMP | MAXTEMP;{NUM} | MAXTEMP;250 | Set the safety temperature threshold in °C The new threshold is activated upon next reboot: Power Off and USB-C disconnect |

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -34,6 +34,7 @@ cmndOff     cmnd_handler_off  = cmndOff( &state );
 cmndOT1     cmnd_handler_ot1  = cmndOT1( &state );
 cmndOT2     cmnd_handler_ot2  = cmndOT2( &state );
 cmndRead    cmnd_handler_read = cmndRead( &state );
+cmndReset   cmnd_handler_reset;
 cmndStat    cmnd_handler_stat = cmndStat( &state );
 #ifdef USE_STEPPER_DRUM
 cmndSteps   cmnd_handler_steps= cmndSteps( &state );
@@ -51,6 +52,7 @@ void setupCommandHandlers(void) {
         &cmnd_handler_steps,
         &cmnd_handler_rpm,
 #endif // USE_STEPPER_DRUM
+        &cmnd_handler_reset,
         &cmnd_handler_maxt,
         &cmnd_handler_abrt,
         &cmnd_handler_version,

--- a/src/commands/handler_dfu.h
+++ b/src/commands/handler_dfu.h
@@ -13,9 +13,9 @@
 #endif // CMD_DFU_TIMEOUT_MS
 
 
-class cmndDFU : public Command {
+class cmndChallenge : public Command {
     public:
-        cmndDFU();
+        cmndChallenge(const char *cmdName): Command(cmdName) {};
     protected:
         void _doCommand( CmndParser* pars);
 
@@ -23,8 +23,29 @@ class cmndDFU : public Command {
         TimerMS timer = TimerMS(CMD_DFU_TIMEOUT_MS);
         int challenge = 0;
 
-        void enterDFU();
         void processChallenge(int response);
+
+    protected:
+        virtual void executeCommand() =0;
 };
+
+
+class cmndDFU : public cmndChallenge {
+    public:
+        cmndDFU();
+    
+    protected:
+        void executeCommand();
+};
+
+
+class cmndReset : public cmndChallenge {
+    public:
+        cmndReset();
+    
+    protected:
+        void executeCommand();
+};
+
 
 #endif // __CMD_DFU_H

--- a/src/eeprom_settings.cpp
+++ b/src/eeprom_settings.cpp
@@ -42,6 +42,10 @@ bool EepromSettings::loopTick() {
 void EepromSettings::print() {
     Serial.print(F("NVM Power On count: "));
     Serial.println(this->settings.counters.powerOnResets);
+    Serial.print(F("NVM Watchdog Reset count: "));
+    Serial.println(this->settings.counters.watchdogResets);
+    Serial.print(F("NVM Software Reset count: "));
+    Serial.println(this->settings.counters.softResets);
     Serial.print(F("NVM Safety triggered count: "));
     Serial.println(this->settings.counters.safetyTriggers);
 #ifdef USE_STEPPER_DRUM
@@ -52,6 +56,7 @@ void EepromSettings::print() {
 #endif  // USE_STEPPER_DRUM
     Serial.print(F("NVM Safety Temperature Threshold C: "));
     Serial.println(this->settings.maxSafeTempC);
+    Serial.println(F("---"));
 }
 
 

--- a/src/eeprom_settings.h
+++ b/src/eeprom_settings.h
@@ -8,7 +8,8 @@
 
 typedef struct {
     uint32_t powerOnResets;
-    uint32_t watchdogReset;
+    uint32_t watchdogResets;
+    uint32_t softResets;
     uint32_t safetyTriggers;
 } t_Counters;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -25,6 +25,7 @@ PROGMEM const static t_Settings nvmSettingsStorage = {
     // Counters
     0, // power on resets
     0, // Watchdog resets
+    0, // Software resets
     0, // safetyTriggers
     EEPROM_SETTINGS_MAGIC, // EEPROM MAGIC number
     0 // CRC
@@ -49,8 +50,14 @@ void setup() {
   Serial.setTimeout(100);
   Serial.println(F(VERSION));
 
-  if (__HAL_RCC_GET_FLAG(RCC_FLAG_BORRST)) {
+  if ( __HAL_RCC_GET_FLAG(RCC_FLAG_BORRST) ) {
       nvmSettings.settings.counters.powerOnResets++;
+      nvmSettings.markDirty();
+  } else if ( __HAL_RCC_GET_FLAG(RCC_FLAG_IWDGRST) ) {
+      nvmSettings.settings.counters.watchdogResets++;
+      nvmSettings.markDirty();
+  } else if ( __HAL_RCC_GET_FLAG(RCC_FLAG_SFTRST) ) {
+      nvmSettings.settings.counters.softResets++;
       nvmSettings.markDirty();
   }
   __HAL_RCC_CLEAR_RESET_FLAGS();


### PR DESCRIPTION
Track Watchdog resets, although, the actual watchdog is not implemented yet.
Track software resets.

Implement software reset command, similar to DFU command. You initiate the reset with the `RESET` Command and being given a challenge. You need to submit the `RESET;{Challenge}` answer within 5s for the reset to occur.