### PR TITLE
Allow changing PWM frequencies for Drum, Exhaust and SSR

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ The following symbols are used for the `Separator` value:
 | OFF | OFF | OFF | Turns everything off. Turns off: cooling, exhaust fan, heater, drum |
 | OT1 | OT1;pp | OT1;50 | where `pp` is the % duty cycle for the heater |
 | OT2 | OT2;pp | OT2;50 | where `pp` is the % duty cycle for the exhause air fan |
+| PWM | PWM;{CTL};{FREQ_HZ} | PWM;SSR;2 | Set PWM frequency for `{CTL}`, where `{CTL}` is: <br>`DRUM` -- Drum driver PWM frequency <br>`EXHAUST` -- Exhaust fan PWM frequency <br>`SSR` -- SSR PWM frequency. <br>The new PWM frequency is applied upon next reboot
 | READ | READ | READ | Requests current temperature readings on all active channels. Response from the device is the ambient temperature followed by a comma separated list of temperatures in current active units in logical channel order: ambient,chan1,chan2,chan3,chan4, followed up by Heater cyty cycle (0 - 100%) and Exhaust Fan duty cycle |
 | RESET | RESET | RESET | Generate the RESET challenge. Software resets the board. The command prompts you a challenge and works similarly to the DFU command |
 | STAT | STAT | STAT | This is an undocumented command. It should print the internal statistics, but currently does not work as expected |

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -7,6 +7,7 @@
 #include "commands/handler_dfu.h"
 #include "commands/handler_filt.h"
 #include "commands/handler_ot.h"
+#include "commands/handler_pwm.h"
 #include "commands/handler_read.h"
 #include "commands/handler_stat.h"
 #include "commands/handler_skywalker.h"
@@ -33,6 +34,7 @@ cmndFilt    cmnd_handler_filt = cmndFilt( &state );
 cmndOff     cmnd_handler_off  = cmndOff( &state );
 cmndOT1     cmnd_handler_ot1  = cmndOT1( &state );
 cmndOT2     cmnd_handler_ot2  = cmndOT2( &state );
+cmndPwm     cmnd_handler_pwm  = cmndPwm( &state );
 cmndRead    cmnd_handler_read = cmndRead( &state );
 cmndReset   cmnd_handler_reset;
 cmndStat    cmnd_handler_stat = cmndStat( &state );
@@ -52,6 +54,7 @@ void setupCommandHandlers(void) {
         &cmnd_handler_steps,
         &cmnd_handler_rpm,
 #endif // USE_STEPPER_DRUM
+        &cmnd_handler_pwm,
         &cmnd_handler_reset,
         &cmnd_handler_maxt,
         &cmnd_handler_abrt,

--- a/src/commands/handler_pwm.cpp
+++ b/src/commands/handler_pwm.cpp
@@ -1,0 +1,61 @@
+#include <cstdlib>
+
+#include "handler_pwm.h"
+
+#define CMD_PWM "PWM"
+#define MIN_PWM 1
+#define MAX_PWM 30000
+
+
+cmndPwm::cmndPwm(State *state):
+    Command( CMD_PWM, state ) {
+}
+
+
+void cmndPwm::_doCommand(CmndParser *pars) {
+    int32_t value = atoi( pars->paramStr(2) );
+    if (( value < MIN_PWM ) || ( value > MAX_PWM )) return;
+
+    if ( strcmp( pars->paramStr(1), "DRUM" ) == 0 ) {
+        this->_setPwmDrum( value );
+    } else if ( strcmp( pars->paramStr(1), "EXHAUST" ) == 0 ) {
+        this->_setPwmExhaust( value );
+    } else if ( strcmp( pars->paramStr(1), "SSR" ) == 0 ) {
+        this->_setPwmSSR( value );
+    }
+}
+
+
+/**
+ * @brief Set PWM frequency for the Drum control
+ */
+void cmndPwm::_setPwmDrum( int32_t value ) {
+    state->nvmSettings->settings.pwmDrumHz = value;
+    state->nvmSettings->markDirty();
+    Serial.print(F("Setting Drum PWM freq to "));
+    Serial.println(value);
+}
+
+
+/**
+ * @brief Set PWM frequency for the Exhaust fan
+ */
+void cmndPwm::_setPwmExhaust( int32_t value ) {
+    state->nvmSettings->settings.pwmExhaustHz = value;
+    state->nvmSettings->markDirty();
+    Serial.print(F("Setting Exhaust FAN PWM freq to "));
+    Serial.println(value);
+}
+
+
+/**
+ * @brief Set PWM frequency for SSR
+ */
+void cmndPwm::_setPwmSSR( int32_t value ) {
+    if ( value > 120 ) return;
+
+    state->nvmSettings->settings.pwmSSRHz = value;
+    state->nvmSettings->markDirty();
+    Serial.print(F("Setting SSR PWM freq to "));
+    Serial.println(value);
+}

--- a/src/commands/handler_pwm.h
+++ b/src/commands/handler_pwm.h
@@ -1,0 +1,18 @@
+#ifndef __CMD_PWN_H
+#define __CMD_PWN_H
+
+#include "base.h"
+#include "eeprom_settings.h"
+
+class cmndPwm : public Command {
+    public:
+        cmndPwm(State *state);
+
+    protected:
+        void _doCommand( CmndParser *pars);
+        void _setPwmDrum( int32_t value );
+        void _setPwmExhaust( int32_t value );
+        void _setPwmSSR( int32_t value );
+};
+
+#endif // __CMD_PWN_H

--- a/src/eeprom_settings.cpp
+++ b/src/eeprom_settings.cpp
@@ -56,6 +56,12 @@ void EepromSettings::print() {
 #endif  // USE_STEPPER_DRUM
     Serial.print(F("NVM Safety Temperature Threshold C: "));
     Serial.println(this->settings.maxSafeTempC);
+    Serial.print(F("NVM PWM frequency Drum Hz: "));
+    Serial.println(this->settings.pwmDrumHz);
+    Serial.print(F("NVM PWM frequency Exhaust fan Hz: "));
+    Serial.println(this->settings.pwmExhaustHz);
+    Serial.print(F("NVM PWM frequency SSR Hz: "));
+    Serial.println(this->settings.pwmSSRHz);
     Serial.println(F("---"));
 }
 

--- a/src/state_commanded.h
+++ b/src/state_commanded.h
@@ -57,7 +57,10 @@ class ControlPWM: public ControlOnOff {
 
 class ControlHeat: public ControlPWM {
     public:
-        ControlHeat(): ControlPWM(PIN_HEAT, PWM_FREQ_HEAT) {};
+        ControlHeat():
+            ControlPWM(PIN_HEAT, PWM_FREQ_HEAT) {};
+        ControlHeat(uint32_t pin=PIN_HEAT, uint32_t freq=PWM_FREQ_HEAT):
+            ControlPWM(pin, freq) {};
         bool begin();
         bool loopTick();
 
@@ -103,13 +106,14 @@ class ControlDrum : public ControlPWM {
 class StateCommanded {
     public:
         StateCommanded(EepromSettings *nvm):
-            vent(ControlPWM(PIN_EXHAUST, PWM_FREQ_EXHAUST)),
+            heat(ControlHeat(PIN_HEAT, nvm->settings.pwmSSRHz)),
+            vent(ControlPWM(PIN_EXHAUST, nvm->settings.pwmExhaustHz)),
 #ifdef USE_STEPPER_DRUM
             drum(ControlDrum(
                 nvm->settings.stepsPerRevolution,
                 nvm->settings.stepsMaxRpm)),
 #else  // USE_STEPPER_DRUM
-            drum(ControlPWM(PIN_DRUM, PWM_FREQ_DRUM)),
+            drum(ControlPWM(PIN_DRUM, nvm->settings.pwmDrumHz)),
 #endif // USE_STEPPER_DRUM
             cool(ControlOnOff(PIN_COOL)),
             _nvmSettings(nvm) {};

--- a/src/state_commanded.h
+++ b/src/state_commanded.h
@@ -80,10 +80,14 @@ class ControlDrum : public ControlPWM {
     public:
         ControlDrum(
             uint16_t stepsPR = STEPPER_STEPS_PER_REV,
-            uint8_t maxRPM = STEPPER_MAX_RPM):
+            uint8_t maxRPM = STEPPER_MAX_RPM,
+            uint32_t pwmDRV8871 = PWM_FREQ_DRUM
+            ):
                 ControlPWM( PIN_STEPPER_STEP, 200 ),
                 _steps_per_rev( stepsPR ),
-                _max_rpm( maxRPM ) {};
+                _max_rpm( maxRPM ),
+                _drum(ControlPWM( PIN_DRUM, pwmDRV8871 ))
+                {}
         bool     begin();
         uint32_t durationFromValue(uint8_t value);
         uint32_t frequencyFromValue(uint8_t value);
@@ -97,7 +101,7 @@ class ControlDrum : public ControlPWM {
         uint16_t     _steps_per_rev;
         uint8_t      _max_rpm;
         ControlOnOff _enable = ControlOnOff( PIN_STEPPER_EN );
-        ControlPWM   _drum   = ControlPWM( PIN_DRUM, PWM_FREQ_DRUM );
+        ControlPWM   _drum;
         void virtual _setPWM(uint8_t value);
         void         _abortAction();
 };
@@ -111,7 +115,8 @@ class StateCommanded {
 #ifdef USE_STEPPER_DRUM
             drum(ControlDrum(
                 nvm->settings.stepsPerRevolution,
-                nvm->settings.stepsMaxRpm)),
+                nvm->settings.stepsMaxRpm,
+                nvm->settings.pwmDrumHz)),
 #else  // USE_STEPPER_DRUM
             drum(ControlPWM(PIN_DRUM, nvm->settings.pwmDrumHz)),
 #endif // USE_STEPPER_DRUM


### PR DESCRIPTION
Add new `PWM` command, to allow setting of PWM frequencies to control:
- DRV8871 Drum driver
- Exhaust FAN control
- SSR

`PWM;DRUM;60` -- Set PWM frequency to 60Hz for DRV8871 Drum driver
`PWM;EXHAUST;70` -- Set PWM frequency to 70Hz for the exhaust fan control
`PWM;SSR;3` -- Set PWM frequency to 3Hz for SSR control
 
All PWM frequency changes are applied upon next reboot/reset.