### PR TITLE
Command to reset eeprom settings to default values

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,8 @@ The following symbols are used for the `Separator` value:
 | DFU | DFU;{num} | DFU;2345 | Answers the DFU challenge. The number is obtained just by the `DFU` command, which gives you the challenge, which you should repeat as `DFU;{challenge}` command within the 5s. If it matches, the MCU enters the DFU mode and the new firmware can be uploaded |
 | DRUM | DRUM;pp | DRUM;90 | Set the drum speed to `pp`%
 | FILT | FILT;ppp;ppp;ppp;ppp | FILT;5;5;5;5 | where ppp = percent filtering on phisical channels 1 to 4. For example `5` indicates how much weight the old value has, so the filtered value = 95% of the new value + 5% of the old value|
+| NVMRST | NVMRST | NVMRST | Resets non-volatile memory settings to defaults. Generates a challenge, which has to be answered within the 5s. This commands works similarly to the `DFU` command |
+| NVMRST | NVMRST;{num} | NVMRST;4523 | Answers the `NVMRST` challenge. See the `DFU` commands for more details |
 | OFF | OFF | OFF | Turns everything off. Turns off: cooling, exhaust fan, heater, drum |
 | OT1 | OT1;pp | OT1;50 | where `pp` is the % duty cycle for the heater |
 | OT2 | OT2;pp | OT2;50 | where `pp` is the % duty cycle for the exhause air fan |

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -31,6 +31,7 @@ cmndCool    cmnd_handler_cool = cmndCool( &state );
 cmndDrum    cmnd_handler_drum = cmndDrum( &state );
 cmndDFU     cmnd_handler_dfu;
 cmndFilt    cmnd_handler_filt = cmndFilt( &state );
+cmndDflts   cmnd_handler_dflt = cmndDflts( &state );
 cmndOff     cmnd_handler_off  = cmndOff( &state );
 cmndOT1     cmnd_handler_ot1  = cmndOT1( &state );
 cmndOT2     cmnd_handler_ot2  = cmndOT2( &state );
@@ -54,6 +55,7 @@ void setupCommandHandlers(void) {
         &cmnd_handler_steps,
         &cmnd_handler_rpm,
 #endif // USE_STEPPER_DRUM
+        &cmnd_handler_dflt,
         &cmnd_handler_pwm,
         &cmnd_handler_reset,
         &cmnd_handler_maxt,

--- a/src/commands/handler_dfu.cpp
+++ b/src/commands/handler_dfu.cpp
@@ -4,6 +4,7 @@
 
 #define CMD_DFU "DFU"
 #define CMD_RESET "RESET"
+#define CMD_NVMRST "NVMRST"
 
 typedef struct {
     uint32_t Initial_SP;
@@ -122,4 +123,13 @@ cmndReset::cmndReset() :
 
 void cmndReset::executeCommand() {
     HAL_NVIC_SystemReset();
+}
+
+cmndDflts::cmndDflts(State *state):
+    cmndChallenge( CMD_NVMRST, state ) {
+}
+
+void cmndDflts::executeCommand() {
+    this->state->nvmSettings->loadDefaults();
+    Serial.println(F("Reset NVM settings to defaults"));
 }

--- a/src/commands/handler_dfu.h
+++ b/src/commands/handler_dfu.h
@@ -16,6 +16,8 @@
 class cmndChallenge : public Command {
     public:
         cmndChallenge(const char *cmdName): Command(cmdName) {};
+        cmndChallenge(const char *cmdName, State *state):
+            Command(cmdName, state) {};
     protected:
         void _doCommand( CmndParser* pars);
 
@@ -42,6 +44,15 @@ class cmndDFU : public cmndChallenge {
 class cmndReset : public cmndChallenge {
     public:
         cmndReset();
+    
+    protected:
+        void executeCommand();
+};
+
+
+class cmndDflts: public cmndChallenge {
+    public:
+        cmndDflts(State *state);
     
     protected:
         void executeCommand();

--- a/src/eeprom_settings.cpp
+++ b/src/eeprom_settings.cpp
@@ -15,10 +15,7 @@ EepromSettings::EepromSettings(const t_Settings *eeprom): defaultSettings(eeprom
     uint16_t crc = calcCRC16((uint8_t *) &settings, offsetof(t_Settings, crc16));
     if ( (settings.crc16 != crc) || (settings.eepromMagic != EEPROM_SETTINGS_MAGIC) )
     {
-        // load the defaults
-        DEBUG(micros()); DEBUGLN(F(" Loading NVM Settings defaults"));
-        memcpy_P(&settings, this->defaultSettings, sizeof(t_Settings));
-        this->save();
+        this->loadDefaults();
     }
 }
 
@@ -74,6 +71,17 @@ void EepromSettings::incSafetyCounter() {
     this->markDirty();
 }
 
+
+/**
+ * @brief Reset settings to default
+ */
+void EepromSettings::loadDefaults() {
+    // load the defaults
+    DEBUG(micros()); DEBUGLN(F(" Loading NVM Settings defaults"));
+    memcpy_P(&settings, this->defaultSettings, sizeof(t_Settings));
+    this->save();
+    this->timer.reset();
+}
 
 /**
  * @brief save the eeprom container

--- a/src/eeprom_settings.h
+++ b/src/eeprom_settings.h
@@ -41,6 +41,7 @@ class EepromSettings {
         void markDirty();
         void print();
         void incSafetyCounter();
+        void loadDefaults();
 
     private:
         TimerMS          timer = TimerMS(EEPROM_SAVE_TIME_MS); 


### PR DESCRIPTION
Resets the settings stored in the NVM (non-volatile memory) to defaults.
The new command is `NVMRST` and behaves similarly to the `DFU` and `RESET` commands, where you first need to get the challenge, just by running the `NVMRST` command, then enter that challenge with the NVMRST command -- `NVMRST;2345` within the 5s of obtaining the challenge.