### PR TITLE
Make default channel mapping 1200

### DIFF
--- a/src/state_reported.cpp
+++ b/src/state_reported.cpp
@@ -11,8 +11,8 @@
 Reported::Reported(Config *config) {
     this->config = config;
 
-    _chanMapping[0] = TEMPERATURE_CHANNEL_ROASTER+1;
-    _chanMapping[1] = TEMPERATURE_CHANNEL_THERMOCOUPLE+1;
+    _chanMapping[0] = TEMPERATURE_CHANNEL_THERMOCOUPLE+1;
+    _chanMapping[1] = TEMPERATURE_CHANNEL_ROASTER+1;
     _chanMapping[2] = 0;
     _chanMapping[3] = 0;
 


### PR DESCRIPTION
Skyduino is using Thermocouple for the physical channel # 1 and the built-in NTC for the physical channel 2. This makes the default physical->logical channel mapping as `CHAN;1200`, meaning Thermocouple is the logical channel 1 AKA `ET` and the built-in NTC is mapped to the logical channel 2 AKA `BT`