### PR TITLE
Implement Status Led

### DIFF
--- a/include/status-led.h
+++ b/include/status-led.h
@@ -1,0 +1,27 @@
+#ifndef _SW_LED_H
+#define _SW_LED_H
+
+#include <Arduino.h>
+#include <roaster.h>
+
+#include "state_commanded.h"
+
+
+/**
+ * @brief Status LED Class
+ *
+ */
+class LEDClass {
+    public:
+        LEDClass( uint32_t pin = PIN_LED ): _pin( pin ) { begin(); }
+        void begin();
+        void turnOff();
+        void turnOn();
+        void toggle();
+    private:
+        const uint32_t _pin;
+        bool _isOn = false;
+};
+
+extern LEDClass StatusLed;
+#endif  // _SW_LED_H

--- a/src/eeprom_settings.cpp
+++ b/src/eeprom_settings.cpp
@@ -5,6 +5,7 @@
 #ifndef __DEBUG__
 #include <IWatchdog.h>
 #endif
+#include <status-led.h>
 
 #include "eeprom_settings.h"
 
@@ -121,7 +122,9 @@ void EepromSettings::save() {
 #ifndef __DEBUG__
     IWatchdog.reload();
 #endif
+    StatusLed.turnOn();
     EEPROM.put(EEPROM_SETTINGS_ADDR, this->settings);
+    StatusLed.turnOff();
     isDirty = false;
 #ifndef __DEBUG__
     IWatchdog.reload();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -125,3 +125,20 @@ void loop() {
 
   state.stats.loopEnd();
 }
+
+extern "C" {
+void HardFault_Handler(void) {
+    LL_GPIO_SetOutputPin(GPIOA, LL_GPIO_PIN_3);        // Turn on the status led
+    uint32_t *stack_pointer = (uint32_t *)__get_MSP(); // Get Main Stack Pointer
+    [[maybe_unused]] uint32_t fault_address = stack_pointer[6];         // Program Counter at fault
+    [[maybe_unused]] uint32_t r0 = stack_pointer[0];   // Register R0
+    [[maybe_unused]] uint32_t r1 = stack_pointer[1];   // Register R1
+    [[maybe_unused]] uint32_t r2 = stack_pointer[2];   // Register R2
+    [[maybe_unused]] uint32_t r3 = stack_pointer[3];   // Register R3
+    [[maybe_unused]] uint32_t r12 = stack_pointer[4];  // Register R12
+    [[maybe_unused]] uint32_t lr = stack_pointer[5];   // Link Register (return address)
+    [[maybe_unused]] uint32_t psr = stack_pointer[7];  // Program Status Register
+    while (1) {
+    }
+}
+}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,6 +3,7 @@
 #ifndef __DEBUG__
 #include <IWatchdog.h>
 #endif
+#include <status-led.h>
 
 #include "roaster.h"
 #include "eeprom_settings.h"
@@ -64,6 +65,8 @@ SafetyMonitor safeMon = SafetyMonitor(
 SkywalkerRemoteComm skwRemoteComm = SkywalkerRemoteComm( &state );
 
 void setup() {
+  StatusLed.begin();
+  StatusLed.turnOn();
   Serial.begin(115200);
   Serial.setTimeout(100);
   Serial.println(F(VERSION));
@@ -102,6 +105,7 @@ void setup() {
 void loop() {
   // for loop timing statistics
   state.stats.loopStart();
+  StatusLed.turnOff();
 
 #ifndef __DEBUG__
   IWatchdog.reload();

--- a/src/status-led.cpp
+++ b/src/status-led.cpp
@@ -1,0 +1,38 @@
+#include "status-led.h"
+
+LEDClass StatusLed = LEDClass( PIN_LED );
+
+
+/**
+ * @brief Initialize LED instance
+ */
+void LEDClass::begin() {
+    pinMode( _pin, OUTPUT );
+    digitalWrite( _pin, LOW );
+    this->_isOn = false;
+}
+
+
+/**
+ * @brief turn the led off
+ */
+void LEDClass::turnOff() {
+    digitalWrite( _pin, LOW );
+    this->_isOn = false;
+}
+
+
+/**
+ * @brief turn the led on
+ */
+void LEDClass::turnOn() {
+    digitalWrite( _pin, HIGH );
+    this->_isOn = true;
+}
+
+/**
+ * @brief Toggle the LED
+ */
+void LEDClass::toggle() {
+    if ( this->_isOn ) this->turnOff(); else this->turnOn();
+}


### PR DESCRIPTION
Use the onboard LED for status.
During the normal operation, the LED is off.

Led will be on:
- during the initialization. Short period, the `setup()` block.
- during the EEPROM writes
- if the hard fault exception is triggered

Usually, after the reset, the status LED will make a short blink for the `Setup()` code block, then in about 10s it will lightup to indicate EEPROM write. Same if you issue `NVM;SAVE` or any other command (like `PWM` ) which updates EEPROM settings.

In other words, normally the LED is going to be off. If the `HardFault_Handler()` is triggered, the LED will turn on, but there's a watchdog timer running, which should reset the controller and LED.