### PR TITLE
Use a "physical" Temp channel for PID;CHAN;x command

### DIFF
--- a/src/state.cpp
+++ b/src/state.cpp
@@ -27,9 +27,9 @@ bool State::begin()
     isSuccess &= commanded.begin();
     isSuccess &= reported.begin();
     isSuccess &= pid.begin();
-    pid.addGetLogicalChantTempC(
+    pid.addCallbackGetChantTempC(
         std::bind(
-            &Reported::getLogicalChanTemp,
+            &Reported::getChanTemp,
             &reported,
             std::placeholders::_1
         )

--- a/src/state_pid.cpp
+++ b/src/state_pid.cpp
@@ -107,7 +107,7 @@ float PID_Control::getTempReadingC() {
         ERRORLN(F("No callback for getChanTempC"));
         return NAN;
     }
-    return this->getChanTempC( _NVM_PIDPROFCURRENT.chan );
+    return this->getChanTempC( _NVM_PIDPROFCURRENT.chan - 1 );
 }
 
 

--- a/src/state_pid.cpp
+++ b/src/state_pid.cpp
@@ -103,11 +103,11 @@ bool PID_Control::setConservProfile(uint8_t profileNum, float setpointGapC) {
  * @return temperature C
  */
 float PID_Control::getTempReadingC() {
-    if ( NULL == getLogicalChanTempC ) {
-        ERRORLN(F("No callback for getLogicalChanTempC"));
+    if ( NULL == getChanTempC ) {
+        ERRORLN(F("No callback for getChanTempC"));
         return NAN;
     }
-    return this->getLogicalChanTempC( _NVM_PIDPROFCURRENT.chan );
+    return this->getChanTempC( _NVM_PIDPROFCURRENT.chan );
 }
 
 

--- a/src/state_pid.h
+++ b/src/state_pid.h
@@ -8,7 +8,7 @@
 #include "state_commanded.h"
 
 
-using t_Cbk_getLogicalChanTempC = std::function< float( uint8_t ) >;
+using t_Cbk_getChanTempC = std::function< float( uint8_t ) >;
 
 class PID_Control {
     public:
@@ -34,7 +34,7 @@ class PID_Control {
         float getSetPoint() { return this->setp; };
         void updateTuning( float kP, float kI, float kD );
         bool updateProfileNTuning( uint8_t profile, float kP, float kI, float kD );
-        void addGetLogicalChantTempC( t_Cbk_getLogicalChanTempC cbk) { getLogicalChanTempC = cbk; };
+        void addCallbackGetChantTempC( t_Cbk_getChanTempC cbk) { getChanTempC = cbk; };
         bool selectFanProfile( uint8_t profileNum );
         FanMode getFanMode() { return this->_fanMode; }
         bool setFanTempGapC( float gap );
@@ -47,7 +47,7 @@ class PID_Control {
         EepromSettings      *_nvm;
         ControlHeat         *_heat;
         ControlPWM          *_vent;
-        t_Cbk_getLogicalChanTempC getLogicalChanTempC = NULL;
+        t_Cbk_getChanTempC  getChanTempC = NULL;
         HardwareTimer       *_timer;
         State               _state = State::needsInit;
         FanMode             _fanMode = FanMode::manual;


### PR DESCRIPTION
Use a "physical" Temp channel for PID;CHAN;x command.

Currently, there are 4 channels:

| Channel | Sensor | PID Command |
| -- | -- | -- |
| 0 | Thermocouple | `PID;CHAN;1` |
| 1 | NTC Probe | `PID;CHAN;2` |
| 2 | not used | n/a |
| 3 | not used | n/a |