### PR TITLE
Refactor NVM initialization

### DIFF
--- a/include/roaster.h
+++ b/include/roaster.h
@@ -56,7 +56,7 @@
 #define PWM_FREQ_LED        120
 
 #define EEPROM_SETTINGS_MAGIC 0xbeefbeef
-#define EEPROM_SAVE_TIME_MS   10000
+#define EEPROM_SAVE_TIME_MS   7000
 #define EEPROM_SETTINGS_ADDR  0
 
 

--- a/src/eeprom_settings.cpp
+++ b/src/eeprom_settings.cpp
@@ -19,6 +19,7 @@ EepromSettings::EepromSettings(const t_Settings *eeprom): defaultSettings(eeprom
     uint16_t crc = calcCRC16((uint8_t *) &settings, offsetof(t_Settings, crc16));
     if ( (settings.crc16 != crc) || (settings.eepromMagic != EEPROM_SETTINGS_MAGIC) )
     {
+        this->_skipWdg = true;
         this->loadDefaults( false );
     }
 }
@@ -148,13 +149,17 @@ void EepromSettings::loadDefaults(bool saveImmediatly) {
 void EepromSettings::save() {
     this->settings.crc16 = calcCRC16((uint8_t *) &settings, offsetof(t_Settings, crc16));
 #ifndef __DEBUG__
-    IWatchdog.set( 30*1000*1000 );
+    if ( !skipWatchdog() ) IWatchdog.set( 30*1000*1000 );
     IWatchdog.reload();
 #endif
     StatusLed.turnOn();
     EEPROM.put(EEPROM_SETTINGS_ADDR, this->settings);
     StatusLed.turnOff();
     isDirty = false;
+    if ( this->skipWatchdog() ) {
+        // this was from a cold eeprom init, so reset it, even if users not gonna like it
+        NVIC_SystemReset();
+    }
 #ifndef __DEBUG__
     IWatchdog.set( WATCHDOG_TIMEOUT_MS * 1000 );
     IWatchdog.reload();

--- a/src/eeprom_settings.cpp
+++ b/src/eeprom_settings.cpp
@@ -19,7 +19,7 @@ EepromSettings::EepromSettings(const t_Settings *eeprom): defaultSettings(eeprom
     uint16_t crc = calcCRC16((uint8_t *) &settings, offsetof(t_Settings, crc16));
     if ( (settings.crc16 != crc) || (settings.eepromMagic != EEPROM_SETTINGS_MAGIC) )
     {
-        this->loadDefaults();
+        this->loadDefaults( false );
     }
 }
 
@@ -119,13 +119,28 @@ void EepromSettings::incSafetyCounter() {
  */
 void EepromSettings::loadDefaults() {
     // load the defaults
+    this->loadDefaults( true );
+}
+
+
+/**
+ * @brief Reset settings to default
+ * @param saveImmediatly -- indicates whether to save to memory immediatly or
+ *        after the "markDirty" timeout
+ */
+void EepromSettings::loadDefaults(bool saveImmediatly) {
+    // load the defaults
 #ifndef __DEBUG__
     IWatchdog.reload();
 #endif
     memcpy_P(&settings, this->defaultSettings, sizeof(t_Settings));
-    this->save();
-    this->timer.reset();
+    this->markDirty();
+    if ( saveImmediatly ) {
+        this->save();
+        this->timer.reset();
+    }
 }
+
 
 /**
  * @brief save the eeprom container

--- a/src/eeprom_settings.h
+++ b/src/eeprom_settings.h
@@ -62,6 +62,7 @@ class EepromSettings {
         void print();
         void incSafetyCounter();
         void loadDefaults();
+        void loadDefaults(bool saveImmediatly);
         void save();
 
     private:

--- a/src/eeprom_settings.h
+++ b/src/eeprom_settings.h
@@ -64,11 +64,13 @@ class EepromSettings {
         void loadDefaults();
         void loadDefaults(bool saveImmediatly);
         void save();
+        bool skipWatchdog() { return _skipWdg; }
 
     private:
         TimerMS          timer = TimerMS(EEPROM_SAVE_TIME_MS); 
         bool             isDirty = false;
         const t_Settings *defaultSettings;
+        bool             _skipWdg = false;
 };
 
 #endif  // __SW_EEPROM_SETTINGS_H

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -87,7 +87,9 @@ void setup() {
   skwRemoteComm.begin();
 
 #ifndef __DEBUG__
-  IWatchdog.begin( WATCHDOG_TIMEOUT_MS * 1000 );
+  if ( !(nvmSettings.skipWatchdog()) ) {
+    IWatchdog.begin( WATCHDOG_TIMEOUT_MS * 1000 );
+  }
 #endif
 
   while ( !(state.begin()) ) {


### PR DESCRIPTION
Fixes cold NVM initialization, as it may take up to 2min to write it back to flash.

Don't enable the watchdog, if the NVM was just initialized.
Delay freshly initialized NVM writing, so the status LED is also initialized.
After the NVM is cold initialized and written to flash, the MCU resets to activate the watchdog.